### PR TITLE
Add global paste shortcut toggle

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -218,6 +218,7 @@ impl HyprwhsprApp {
 
         let text_injector = TextInjector::new(
             config.shift_paste,
+            config.global_paste_shortcut,
             config.paste_hints.shift.clone(),
             config.word_overrides.clone(),
             config.auto_copy_clipboard,
@@ -375,6 +376,7 @@ impl HyprwhsprApp {
 
         let text_injector = TextInjector::new(
             new_config.shift_paste,
+            new_config.global_paste_shortcut,
             new_config.paste_hints.shift.clone(),
             new_config.word_overrides.clone(),
             new_config.auto_copy_clipboard,

--- a/src/app_test.rs
+++ b/src/app_test.rs
@@ -58,6 +58,7 @@ impl HyprwhsprAppTest {
 
         let text_injector = TextInjector::new(
             config.shift_paste,
+            config.global_paste_shortcut,
             config.paste_hints.shift.clone(),
             config.word_overrides.clone(),
             config.auto_copy_clipboard,
@@ -117,6 +118,7 @@ impl HyprwhsprAppTest {
 
         let text_injector = TextInjector::new(
             new_config.shift_paste,
+            new_config.global_paste_shortcut,
             new_config.paste_hints.shift.clone(),
             new_config.word_overrides.clone(),
             new_config.auto_copy_clipboard,

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,6 +77,9 @@ pub struct Config {
     pub shift_paste: bool,
 
     #[serde(default)]
+    pub global_paste_shortcut: bool,
+
+    #[serde(default)]
     pub paste_hints: PasteHintsConfig,
 
     #[serde(default)]
@@ -439,6 +442,7 @@ impl Default for Config {
             stop_sound_path: None,
             auto_copy_clipboard: default_auto_copy_clipboard(),
             shift_paste: default_shift_paste(),
+            global_paste_shortcut: false,
             paste_hints: PasteHintsConfig::default(),
             audio_device: None,
             fast_vad: FastVadConfig::default(),


### PR DESCRIPTION
## Summary
- add config flag to enable universal Shift+Insert paste
- route Hyprland, virtual keyboard, and Enigo paths through shift-insert when flag is on

## Testing
- cargo build --release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added global paste shortcut functionality enabling universal paste across windows with multiple fallback methods for enhanced compatibility.

* **Configuration**
  * New `global_paste_shortcut` boolean configuration option available (disabled by default).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->