### PR TITLE
fix: add empty guard after preprocess_text to prevent empty clipboard

### DIFF
--- a/src/input/injector.rs
+++ b/src/input/injector.rs
@@ -908,6 +908,11 @@ impl TextInjector {
         // Preprocess text
         let processed = self.preprocess_text(text);
 
+        if processed.is_empty() {
+            debug!("Text became empty after preprocessing, nothing to inject");
+            return Ok(());
+        }
+
         info!("Injecting text: {} characters", processed.len());
 
         // Copy to clipboard using available backends
@@ -1014,6 +1019,10 @@ impl TextInjector {
     }
 
     fn copy_processed_text(&mut self, text: &str) -> Result<()> {
+        if text.is_empty() {
+            return Ok(());
+        }
+
         if self.wayland_clipboard_enabled {
             match self.copy_wayland_clipboard(text) {
                 Ok(_) => {


### PR DESCRIPTION
## Summary

- Adds guard after `preprocess_text()` to prevent copying empty strings to clipboard
- Adds defense-in-depth guard in `copy_processed_text()`

Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty text input to prevent unnecessary operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->