### PR TITLE
feat: systemd, walker/elephant config, and waybar

### DIFF
--- a/config/elephant/hyprwhspr.lua
+++ b/config/elephant/hyprwhspr.lua
@@ -1,0 +1,61 @@
+-- hyprwhspr Walker/Elephant Menu
+-- Copy to: ~/.config/elephant/menus/hyprwhspr.lua
+--
+-- Displays recent voice transcriptions with click-to-copy.
+-- Invoke with: walker --provider menus:hyprwhspr
+
+Name = "hyprwhspr"
+NamePretty = "Recent Transcriptions"
+Icon = "audio-input-microphone"
+Cache = false
+HideFromProviderlist = false
+FixedOrder = true
+Description = "Recent voice transcriptions"
+
+function GetEntries()
+    local entries = {}
+    local home = os.getenv("HOME")
+    local file_path = home .. "/.local/share/hyprwhspr/transcriptions.json"
+
+    local file = io.open(file_path, "r")
+    if not file then
+        return entries
+    end
+
+    local content = file:read("*all")
+    file:close()
+
+    local items = jsonDecode(content)
+    if not items then
+        return entries
+    end
+
+    for i, item in ipairs(items) do
+        local display = item.text or ""
+        if #display > 60 then
+            display = string.sub(display, 1, 57) .. "..."
+        end
+
+        table.insert(entries, {
+            Text = display,
+            Subtext = item.timestamp or "",
+            Value = item.text or "",
+            Icon = "edit-copy",
+            Preview = item.text or "",
+            PreviewType = "text",
+        })
+    end
+
+    return entries
+end
+
+-- Safe copy handling special characters
+Action = "lua:CopyToClipboard"
+
+function CopyToClipboard(value, args)
+    local handle = io.popen("wl-copy", "w")
+    if handle then
+        handle:write(value)
+        handle:close()
+    end
+end

--- a/config/systemd/hyprwhspr-rs.service
+++ b/config/systemd/hyprwhspr-rs.service
@@ -1,9 +1,16 @@
 [Unit]
 Description=hyprwhspr-rs Voice Dictation Service
 After=graphical-session.target pipewire.service
-Wants=
+Wants=pipewire.service
 
 [Service]
+Type=simple
+ExecStart=%h/.cargo/bin/hyprwhspr-rs
+ExecStartPost=/bin/sh -c 'mkdir -p %h/.cache/hyprwhspr && echo "{\"text\":\"\",\"class\":\"inactive\",\"tooltip\":\"Ready\"}" > %h/.cache/hyprwhspr/status.json && pkill -RTMIN+8 waybar || true'
+ExecStopPost=/bin/sh -c 'rm -f %h/.cache/hyprwhspr/status.json && pkill -RTMIN+8 waybar || true'
+Restart=on-failure
+RestartSec=3
+Environment=RUST_LOG=info
 
 [Install]
 WantedBy=default.target

--- a/config/waybar/hyprwhspr-module.jsonc
+++ b/config/waybar/hyprwhspr-module.jsonc
@@ -1,3 +1,9 @@
 {
-  "custom/hyprwhspr-rs": {}
+  "custom/hyprwhspr": {
+    "exec": "cat ~/.cache/hyprwhspr/status.json 2>/dev/null || echo '{\"text\":\"\",\"class\":\"inactive\",\"tooltip\":\"Not running\"}'",
+    "return-type": "json",
+    "interval": 0,
+    "signal": 8,
+    "on-click": "walker --provider menus:hyprwhspr"
+  }
 }

--- a/config/waybar/hyprwhspr-style.css
+++ b/config/waybar/hyprwhspr-style.css
@@ -1,17 +1,44 @@
-/* hyprwhspr Waybar Styling */
+/* hyprwhspr Waybar Styling
+ *
+ * These are example styles - customize to match your theme.
+ * Uses class-based styling so you can respect monochrome/themed setups.
+ * Uncomment and modify colors as needed.
+ */
 
-/* Base styles - same icon for all states, only colors change */
 #custom-hyprwhspr {
+  /* Base styles */
+  padding: 0 8px;
+  /* font-family: "Symbols Nerd Font Mono"; */
 }
 
-#custom-hyprwhspr.ready {
+/* Inactive: hidden or minimal */
+#custom-hyprwhspr.inactive {
+  /* color: @text-muted; */
+  /* opacity: 0.5; */
 }
 
-#custom-hyprwhspr.recording {
+/* Active: recording */
+#custom-hyprwhspr.active {
+  /* color: @green; */
+  /* color: #a6e3a1; */
 }
 
+/* Processing: transcribing */
+#custom-hyprwhspr.processing {
+  /* color: @yellow; */
+  /* color: #f9e2af; */
+  /* animation: pulse 1s ease-in-out infinite; */
+}
+
+/* Error state */
 #custom-hyprwhspr.error {
+  /* color: @red; */
+  /* color: #f38ba8; */
 }
 
-#custom-hyprwhspr:hover {
+/*
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
 }
+*/

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,50 +1,196 @@
 use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
+use std::process::Command;
 
-/// Writes recording status for Waybar tray script to read
+/// XDG-compliant paths for hyprwhspr data
+pub mod paths {
+    use std::path::PathBuf;
+
+    /// ~/.cache/hyprwhspr/ - ephemeral status for Waybar
+    pub fn cache_dir() -> PathBuf {
+        directories::BaseDirs::new()
+            .map(|d| d.cache_dir().join("hyprwhspr"))
+            .unwrap_or_else(|| PathBuf::from("/tmp/hyprwhspr"))
+    }
+
+    /// ~/.local/share/hyprwhspr/ - persistent transcription history
+    pub fn data_dir() -> PathBuf {
+        directories::BaseDirs::new()
+            .map(|d| d.data_dir().join("hyprwhspr"))
+            .unwrap_or_else(|| PathBuf::from("/tmp/hyprwhspr"))
+    }
+
+    pub fn status_file() -> PathBuf {
+        cache_dir().join("status.json")
+    }
+
+    pub fn history_file() -> PathBuf {
+        data_dir().join("transcriptions.json")
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WaybarState {
+    Inactive,
+    Active,
+    Processing,
+    Error,
+}
+
+impl WaybarState {
+    fn icon(&self) -> &'static str {
+        match self {
+            Self::Inactive => "",
+            Self::Active => "󰍬",
+            Self::Processing => "󰍬",
+            Self::Error => "err",
+        }
+    }
+
+    fn class(&self) -> &'static str {
+        match self {
+            Self::Inactive => "inactive",
+            Self::Active => "active",
+            Self::Processing => "processing",
+            Self::Error => "error",
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct WaybarStatus {
+    text: String,
+    tooltip: String,
+    class: String,
+    alt: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TranscriptionEntry {
+    pub text: String,
+    pub timestamp: String,
+}
+
+/// Writes recording status for Waybar to read (JSON format)
 pub struct StatusWriter {
     status_file: PathBuf,
+    history_file: PathBuf,
+    max_history: usize,
 }
 
 impl StatusWriter {
     pub fn new() -> Result<Self> {
-        let config_dir = directories::ProjectDirs::from("", "", "hyprwhspr-rs")
-            .context("Failed to get config directory")?
-            .config_dir()
-            .to_path_buf();
+        let status_file = paths::status_file();
+        let history_file = paths::history_file();
 
-        fs::create_dir_all(&config_dir).context("Failed to create config directory")?;
+        fs::create_dir_all(paths::cache_dir()).context("Failed to create cache directory")?;
+        fs::create_dir_all(paths::data_dir()).context("Failed to create data directory")?;
 
         Ok(Self {
-            status_file: config_dir.join("recording_status"),
+            status_file,
+            history_file,
+            max_history: 20,
         })
     }
 
-    /// Set recording status
-    /// - recording=true: writes "true" to file
-    /// - recording=false: removes the file (matches Python behavior)
+    /// Update Waybar status with state and tooltip
+    pub fn set_state(&self, state: WaybarState, tooltip: &str) -> Result<()> {
+        let status = WaybarStatus {
+            text: state.icon().to_string(),
+            tooltip: tooltip.to_string(),
+            class: state.class().to_string(),
+            alt: state.class().to_string(),
+        };
+
+        let json = serde_json::to_string(&status).context("Failed to serialize status")?;
+        fs::write(&self.status_file, &json).context("Failed to write status file")?;
+
+        tracing::debug!(state = ?state, tooltip = %tooltip, "Updated Waybar status");
+
+        self.signal_waybar();
+        Ok(())
+    }
+
+    /// Legacy method for backward compatibility
     pub fn set_recording(&self, recording: bool) -> Result<()> {
         if recording {
-            fs::write(&self.status_file, "true").context("Failed to write recording status")?;
-            tracing::debug!("Set recording status: true");
+            self.set_state(WaybarState::Active, "Recording...")
         } else {
-            // Remove file when not recording to avoid stale state
-            if self.status_file.exists() {
-                fs::remove_file(&self.status_file)
-                    .context("Failed to remove recording status file")?;
-                tracing::debug!("Removed recording status file");
-            }
+            self.set_state(WaybarState::Inactive, "Ready")
         }
-        Ok(())
+    }
+
+    /// Set processing state (transcribing)
+    pub fn set_processing(&self) -> Result<()> {
+        self.set_state(WaybarState::Processing, "Transcribing...")
+    }
+
+    /// Set error state with message
+    pub fn set_error(&self, message: &str) -> Result<()> {
+        self.set_state(WaybarState::Error, &format!("Error: {}", message))
     }
 
     pub fn is_recording(&self) -> bool {
         if let Ok(content) = fs::read_to_string(&self.status_file) {
-            content.trim() == "true"
-        } else {
-            false
+            if let Ok(status) = serde_json::from_str::<WaybarStatus>(&content) {
+                return status.class == "active";
+            }
         }
+        false
+    }
+
+    /// Save transcription to history (for Walker/Elephant integration)
+    pub fn save_transcription(&self, text: &str) -> Result<()> {
+        let mut entries: Vec<TranscriptionEntry> = fs::read_to_string(&self.history_file)
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default();
+
+        let timestamp = time::OffsetDateTime::now_local()
+            .unwrap_or_else(|_| time::OffsetDateTime::now_utc())
+            .format(
+                &time::format_description::parse("[year]-[month]-[day] [hour]:[minute]")
+                    .expect("valid format"),
+            )
+            .unwrap_or_else(|_| "unknown".to_string());
+
+        entries.insert(
+            0,
+            TranscriptionEntry {
+                text: text.to_string(),
+                timestamp,
+            },
+        );
+
+        entries.truncate(self.max_history);
+
+        let json =
+            serde_json::to_string_pretty(&entries).context("Failed to serialize history")?;
+        fs::write(&self.history_file, json).context("Failed to write history file")?;
+
+        tracing::debug!(entries = entries.len(), "Saved transcription to history");
+        Ok(())
+    }
+
+    /// Signal Waybar to refresh the custom module
+    fn signal_waybar(&self) {
+        // SIGRTMIN+8 = signal 8 for custom module refresh
+        let _ = Command::new("pkill")
+            .args(["-RTMIN+8", "waybar"])
+            .spawn()
+            .map(|mut child| child.wait());
+    }
+
+    /// Clean up status file on shutdown
+    pub fn cleanup(&self) -> Result<()> {
+        if self.status_file.exists() {
+            fs::remove_file(&self.status_file).context("Failed to remove status file")?;
+            self.signal_waybar();
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
src/status.rs:
- added paths module with XDG-compliant helpers
- new WaybarState enum with icon/class mappings
- TranscriptionEntry struct for history
- set_state(), set_processing(), set_error() methods
- save_transcription() writes JSON history
- signal_waybar() sends SIGRTMIN+8 on state changes
- cleanup() removes status file on shutdown

src/app.rs:
- Recording/activity state (active, processing, inactive, error)
- After transcription saves to history, returns inactive
- On error -> briefly, then inactive
- Cleanup calls status_writer.cleanup()

other changes:
- config stuff in config/*

work needed:
- install script
- documentation updates

Closes #43 
Closes #44 
Closes #45 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recent transcriptions menu with one-click copy-to-clipboard functionality.
  * Transcription history now persists locally for quick access to past recordings.
  * Enhanced status indicators showing idle, active, processing, and error states.

* **Chores**
  * Improved system integration and service configuration for stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->