### PR TITLE
fix: copy walker history selection to clipboard

### DIFF
--- a/config/elephant/hyprwhspr.lua
+++ b/config/elephant/hyprwhspr.lua
@@ -53,13 +53,6 @@ function GetEntries()
     return entries
 end
 
--- Safe copy handling special characters
-Action = "lua:CopyToClipboard"
-
-function CopyToClipboard(value, args)
-    local handle = io.popen("wl-copy", "w")
-    if handle then
-        handle:write(value)
-        handle:close()
-    end
-end
+-- Copy selected entry to clipboard.
+-- Elephant pipes `Value` to stdin when no %VALUE%.
+Action = "wl-copy"


### PR DESCRIPTION
## Summary
- Pipe the selected entry `Value` into `wl-copy` so activating an item reliably updates the clipboard.

## Testing
- `cargo build --release`

Closes #55.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined clipboard copy functionality for improved reliability and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->