### PR TITLE
fix: order for waybar config loading

### DIFF
--- a/src/install/waybar.rs
+++ b/src/install/waybar.rs
@@ -25,7 +25,7 @@ fn waybar_config_dir() -> PathBuf {
 
 fn find_waybar_config() -> Option<PathBuf> {
     let dir = waybar_config_dir();
-    for name in ["config.jsonc", "config.json", "config"] {
+    for name in ["config", "config.jsonc"] {
         let path = dir.join(name);
         if path.exists() {
             return Some(path);


### PR DESCRIPTION
Waybar does not read from a `config.json` file at all. Additionally, if both config and config.jsonc are present, Waybar prefers to read from the config file, so that should be read first.

See: https://github.com/Alexays/Waybar/blob/master/src/config.cpp#L215