### PR TITLE
fix: conditional bail import

### DIFF
--- a/src/transcription/mod.rs
+++ b/src/transcription/mod.rs
@@ -8,7 +8,9 @@ mod prompt;
 
 use crate::config::{Config, ConfigManager, TranscriptionProvider};
 use crate::whisper::{WhisperManager, WhisperVadOptions};
-use anyhow::{bail, Context, Result};
+#[cfg(not(feature = "parakeet"))]
+use anyhow::bail;
+use anyhow::{Context, Result};
 use std::env;
 use std::time::Duration;
 #[cfg(feature = "parakeet")]


### PR DESCRIPTION
Cargo check was giving warnings without moving the bail import to be conditional.