### PR TITLE
fix: regex parsing

### DIFF
--- a/src/install/waybar.rs
+++ b/src/install/waybar.rs
@@ -25,7 +25,7 @@ fn waybar_config_dir() -> PathBuf {
 
 fn find_waybar_config() -> Option<PathBuf> {
     let dir = waybar_config_dir();
-    for name in ["config.jsonc", "config.json", "config"] {
+    for name in ["config", "config.jsonc"] {
         let path = dir.join(name);
         if path.exists() {
             return Some(path);


### PR DESCRIPTION
The `regex` crate does not support back references as were being used in the `clean_jsonc` function. Additionally, this function is not necessary at all as we just need to parse the jsonc file, which will ignore comments on its own.