### PR TITLE
chore: release v0.3.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.3.17] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.16...v0.3.17) - 2026-02-03
+
+### Features
+- warn log/info on missing model & hardcode default models dir ([#88](https://github.com/better-slop/hyprwhspr-rs/pull/88))
+
+
+### Fixes
+- model load order ([#89](https://github.com/better-slop/hyprwhspr-rs/pull/89))
+- shortcut is bound to keybind + `alt` key when alt is omitted ([#86](https://github.com/better-slop/hyprwhspr-rs/pull/86))
+
 ## [0.3.16] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.15...v0.3.16) - 2026-01-26
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "hyprwhspr-rs"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyprwhspr-rs"
-version = "0.3.16"
+version = "0.3.17"
 edition = "2021"
 authors = ["hyprwhspr-rs contributors"]
 description = "Native speech-to-text voice dictation for Hyprland (Rust implementation)"


### PR DESCRIPTION



## 🤖 New release

* `hyprwhspr-rs`: 0.3.16 -> 0.3.17 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.17] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.16...v0.3.17) - 2026-02-03

### Features
- warn log/info on missing model & hardcode default models dir ([#88](https://github.com/better-slop/hyprwhspr-rs/pull/88))


### Fixes
- model load order ([#89](https://github.com/better-slop/hyprwhspr-rs/pull/89))
- shortcut is bound to keybind + `alt` key when alt is omitted ([#86](https://github.com/better-slop/hyprwhspr-rs/pull/86))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).