### PR TITLE
chore: release v0.3.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.3.18] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.17...v0.3.18) - 2026-02-10
+
+### Chores
+- *(deps)* bump time from 0.3.44 to 0.3.47 ([#95](https://github.com/better-slop/hyprwhspr-rs/pull/95))
+- *(docs)* update integration examples & adds contributing.md ([#90](https://github.com/better-slop/hyprwhspr-rs/pull/90))
+
+
+### Features
+- update actions ([#96](https://github.com/better-slop/hyprwhspr-rs/pull/96))
+
+
+### Other
+- paths ([#93](https://github.com/better-slop/hyprwhspr-rs/pull/93))
+- Migrate workflows to Blacksmith ([#94](https://github.com/better-slop/hyprwhspr-rs/pull/94))
+
 ## [0.3.17] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.16...v0.3.17) - 2026-02-03
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "hyprwhspr-rs"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyprwhspr-rs"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2021"
 authors = ["hyprwhspr-rs contributors"]
 description = "Native speech-to-text voice dictation for Hyprland (Rust implementation)"


### PR DESCRIPTION



## 🤖 New release

* `hyprwhspr-rs`: 0.3.17 -> 0.3.18 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.18] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.17...v0.3.18) - 2026-02-10

### Chores
- *(deps)* bump time from 0.3.44 to 0.3.47 ([#95](https://github.com/better-slop/hyprwhspr-rs/pull/95))
- *(docs)* update integration examples & adds contributing.md ([#90](https://github.com/better-slop/hyprwhspr-rs/pull/90))


### Features
- update actions ([#96](https://github.com/better-slop/hyprwhspr-rs/pull/96))


### Other
- paths ([#93](https://github.com/better-slop/hyprwhspr-rs/pull/93))
- Migrate workflows to Blacksmith ([#94](https://github.com/better-slop/hyprwhspr-rs/pull/94))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).