### PR TITLE
chore: release v0.3.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.3.20] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.19...v0.3.20) - 2026-02-10
+
+### Chores
+- fmt readme
+- *(docs)* mention `--no-default-features` install in readme
+
 ## [0.3.19] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.18...v0.3.19) - 2026-02-10
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "hyprwhspr-rs"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyprwhspr-rs"
-version = "0.3.19"
+version = "0.3.20"
 edition = "2021"
 authors = ["hyprwhspr-rs contributors"]
 description = "Native speech-to-text voice dictation for Hyprland (Rust implementation)"


### PR DESCRIPTION



## 🤖 New release

* `hyprwhspr-rs`: 0.3.19 -> 0.3.20 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.20] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.19...v0.3.20) - 2026-02-10

### Chores
- fmt readme
- *(docs)* mention `--no-default-features` install in readme
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).