### PR TITLE
chore: release v0.3.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.3.21] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.20...v0.3.21) - 2026-03-03
+
+### Chores
+- api key docs ([#105](https://github.com/better-slop/hyprwhspr-rs/pull/105))
+
+
+### Docs
+- add nix usage to readme ([#80](https://github.com/better-slop/hyprwhspr-rs/pull/80))
+
+
+### Features
+- more badges
+- readme badges
+
+
+### Fixes
+- lazy-init enigo fallback to avoid idle suppression ([#107](https://github.com/better-slop/hyprwhspr-rs/pull/107))
+
 ## [0.3.20] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.19...v0.3.20) - 2026-02-10
 
 ### Chores

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "hyprwhspr-rs"
-version = "0.3.20"
+version = "0.3.21"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyprwhspr-rs"
-version = "0.3.20"
+version = "0.3.21"
 edition = "2021"
 authors = ["hyprwhspr-rs contributors"]
 description = "Native speech-to-text voice dictation for Hyprland (Rust implementation)"


### PR DESCRIPTION



## 🤖 New release

* `hyprwhspr-rs`: 0.3.20 -> 0.3.21 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.21] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.20...v0.3.21) - 2026-03-03

### Chores
- api key docs ([#105](https://github.com/better-slop/hyprwhspr-rs/pull/105))


### Docs
- add nix usage to readme ([#80](https://github.com/better-slop/hyprwhspr-rs/pull/80))


### Features
- more badges
- readme badges


### Fixes
- lazy-init enigo fallback to avoid idle suppression ([#107](https://github.com/better-slop/hyprwhspr-rs/pull/107))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).