### PR TITLE
fix: upgrade parakeet-rs for ort rc12 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,9 +2167,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5df903c0d2c07b56950f1058104ab0c8557159f2741782223704de9be73c3c"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
  "ndarray",
  "ort-sys",
@@ -2180,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",
@@ -2211,15 +2211,15 @@ dependencies = [
 
 [[package]]
 name = "parakeet-rs"
-version = "0.2.9"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7667842fd2f3b97b029a30fb9a00138867c6915229f5acd6bd809d08250d2ee"
+checksum = "ac2c29bb70e3b63ddfa9af7cbb66f87a200550a5f6a5ac82fabf527b270c6615"
 dependencies = [
  "eyre",
  "hound",
  "ndarray",
  "ort",
- "rustfft",
+ "realfft",
  "serde",
  "serde_json",
  "tokenizers",
@@ -2551,6 +2551,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "realfft"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
+dependencies = [
+ "rustfft",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ wl-clipboard-rs = "0.9"
 wrtype = "0.1"
 
 # Parakeet TDT (NVIDIA ASR)
-parakeet-rs = { version = "0.2.7", optional = true }
+parakeet-rs = { version = "0.3.4", optional = true }
 
 # Logging
 tracing = "0.1"


### PR DESCRIPTION
## Summary
- upgrade `parakeet-rs` from the broken `0.2.x` line to `0.3.4`
- refresh the lockfile so Cargo resolves to the compatible `ort 2.0.0-rc.12` stack
- restore clean `cargo install` / release builds when dependency resolution drifts past the old lockfile

## Why
`parakeet-rs 0.2.9` compiles against the older `ort` builder API but its semver range allows newer `ort` prereleases. When Cargo resolves to `ort 2.0.0-rc.12`, the builder methods return `Error<SessionBuilder>` and the old crate stops compiling during install/build.

## Verification
- `cargo test`
- `cargo build --release`
