### PR TITLE
chore: release v0.3.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.3.25] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.24...v0.3.25) - 2026-04-16
+
+### Fixes
+- upgrade parakeet-rs for ort rc12 compatibility ([#121](https://github.com/better-slop/hyprwhspr-rs/pull/121))
+
 ## [0.3.24] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.23...v0.3.24) - 2026-04-16
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "hyprwhspr-rs"
-version = "0.3.24"
+version = "0.3.25"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyprwhspr-rs"
-version = "0.3.24"
+version = "0.3.25"
 edition = "2021"
 authors = ["hyprwhspr-rs contributors"]
 description = "Native speech-to-text voice dictation for Hyprland (Rust implementation)"


### PR DESCRIPTION



## 🤖 New release

* `hyprwhspr-rs`: 0.3.24 -> 0.3.25 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.25] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.24...v0.3.25) - 2026-04-16

### Fixes
- upgrade parakeet-rs for ort rc12 compatibility ([#121](https://github.com/better-slop/hyprwhspr-rs/pull/121))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).