### PR TITLE
feat: custom providers/openai compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ https://github.com/user-attachments/assets/bbbaa1c3-1a7e-4165-ad3d-27b7465e201a
 - Groq or Gemini API key (optional)
   - Use `GROQ_API_KEY` for provider `groq`
   - Use `GEMINI_API_KEY` for provider `gemini`
+  - Custom OpenAI-compatible providers can read API keys from env vars or secret files.
   - Groq with whisper is cheap (~$0.10 USD/month) and fast as hell. [[Data Controls](https://console.groq.com/settings/data-controls)]
   - Comparatively, Gemini is very slow but offers better output formatting.
 - Parakeet TDT (optional) - NVIDIA's local ASR model via ONNX
@@ -221,7 +222,7 @@ bind = ALT, SPACE, exec, hyprwhspr-rs record toggle
     "volatility_decrease_threshold": 0.12, // Relax profile when toggles stay below this ratio
   },
   "transcription": {
-    "provider": "whisper_cpp", // whisper_cpp | groq | gemini | parakeet
+    "provider": "whisper_cpp", // whisper_cpp | groq | gemini | parakeet | custom.<name>
     "request_timeout_secs": 45,
     "max_retries": 2,
     "whisper_cpp": {
@@ -265,6 +266,27 @@ bind = ALT, SPACE, exec, hyprwhspr-rs record toggle
       "model_dir": "models/parakeet/parakeet-tdt-0.6b-v3-onnx", // Relative to $XDG_DATA_HOME/hyprwhspr-rs (or ~/.local/share/hyprwhspr-rs)
       "prompt": "Transcribe as technical documentation with proper capitalization, acronyms, and technical terminology. Do not add punctuation.",
     },
+    "custom": {
+      "remote_whisper": {
+        "kind": "openai_audio_transcriptions",
+        "label": "Remote whisper.cpp",
+        "base_url": {
+          "env": "HYPRWHSPR_REMOTE_WHISPER_BASE_URL",
+          "value": "http://localhost:8080",
+        },
+        "endpoint": "/v1/audio/transcriptions",
+        "model": "whisper-large-v3",
+        "audio_format": "wav", // wav | flac; wav works with whisper.cpp server by default
+        "api_key": {
+          "env": "HYPRWHSPR_REMOTE_WHISPER_API_KEY",
+          "file": "/run/secrets/hyprwhspr-remote-key",
+          "file_env": "HYPRWHSPR_REMOTE_WHISPER_API_KEY_FILE",
+        },
+        "headers": {},
+        "body": {},
+        "prompt": "Transcribe as technical documentation with proper capitalization, acronyms, and technical terminology. Do not add punctuation.",
+      },
+    },
   },
 }
 ```
@@ -284,6 +306,39 @@ Use <code>transcription.provider</code> in <code>~/.config/hyprwhspr-rs/config.j
 - groq provider <strong>requires</strong>: <code>GROQ_API_KEY</code>
 - gemini provider <strong>requires</strong>: <code>GEMINI_API_KEY</code>
 - whisper_cpp (whisper-cli) <strong>does not require an API key; the binary is discovered via <code>PATH</code> and managed locations under <code>$XDG_DATA_HOME</code> / <code>$HOME</code></strong>
+- custom providers use <code>transcription.custom.&lt;name&gt;.api_key</code>. Secret resolution prefers <code>file_env</code>, then <code>file</code>, then <code>env</code>. Empty/missing keys are allowed for no-auth local servers.
+
+#### Custom OpenAI-compatible providers
+
+Set <code>transcription.provider</code> to <code>custom.&lt;name&gt;</code>, then define <code>transcription.custom.&lt;name&gt;</code>.
+
+```jsonc
+"transcription": {
+  "provider": "custom.remote_whisper",
+  "custom": {
+    "remote_whisper": {
+      "kind": "openai_audio_transcriptions",
+      "label": "Remote whisper.cpp",
+      "base_url": {
+        "env": "HYPRWHSPR_REMOTE_WHISPER_BASE_URL",
+        "value": "http://localhost:8080"
+      },
+      "endpoint": "/v1/audio/transcriptions",
+      "model": "whisper-large-v3",
+      "api_key": {
+        "env": "HYPRWHSPR_REMOTE_WHISPER_API_KEY",
+        "file": "/run/secrets/hyprwhspr-remote-key",
+        "file_env": "HYPRWHSPR_REMOTE_WHISPER_API_KEY_FILE"
+      },
+      "headers": {},
+      "body": {},
+      "prompt": "Transcribe technical notes."
+    }
+  }
+}
+```
+
+For <code>whisper.cpp/examples/server</code>, start the server with <code>--inference-path /v1/audio/transcriptions</code> or set <code>endpoint</code> to <code>/inference</code>. Custom providers default to WAV uploads so the server does not need <code>--convert</code>.
 
 #### Recommended setup (systemd user service)
 

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ https://github.com/user-attachments/assets/bbbaa1c3-1a7e-4165-ad3d-27b7465e201a
 - Groq or Gemini API key (optional)
   - Use `GROQ_API_KEY` for provider `groq`
   - Use `GEMINI_API_KEY` for provider `gemini`
-  - Custom OpenAI-compatible providers can read API keys from env vars or secret files.
   - Groq with whisper is cheap (~$0.10 USD/month) and fast as hell. [[Data Controls](https://console.groq.com/settings/data-controls)]
   - Comparatively, Gemini is very slow but offers better output formatting.
 - Parakeet TDT (optional) - NVIDIA's local ASR model via ONNX
   - Run `./scripts/download-parakeet-tdt.sh` to download model files (~1.2GB)
   - Very fast, but not as accurate as whisper or Gemini
+- Custom OpenAI-compatible providers see [below](#custom-openai-compatible-providers)
 
 ## Features
 
@@ -266,6 +266,7 @@ bind = ALT, SPACE, exec, hyprwhspr-rs record toggle
       "model_dir": "models/parakeet/parakeet-tdt-0.6b-v3-onnx", // Relative to $XDG_DATA_HOME/hyprwhspr-rs (or ~/.local/share/hyprwhspr-rs)
       "prompt": "Transcribe as technical documentation with proper capitalization, acronyms, and technical terminology. Do not add punctuation.",
     },
+    // "provider": "custom.remote_whisper",
     "custom": {
       "remote_whisper": {
         "kind": "openai_audio_transcriptions",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ https://github.com/user-attachments/assets/bbbaa1c3-1a7e-4165-ad3d-27b7465e201a
 - Parakeet TDT (optional) - NVIDIA's local ASR model via ONNX
   - Run `./scripts/download-parakeet-tdt.sh` to download model files (~1.2GB)
   - Very fast, but not as accurate as whisper or Gemini
-- Custom OpenAI-compatible providers see [below](#custom-openai-compatible-providers)
+- For custom OpenAI-compatible providers, see [configuration](#configuration) below
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Use <code>transcription.provider</code> in <code>~/.config/hyprwhspr-rs/config.j
 
 - groq provider <strong>requires</strong>: <code>GROQ_API_KEY</code>
 - gemini provider <strong>requires</strong>: <code>GEMINI_API_KEY</code>
-- whisper_cpp (whisper-cli) <strong>does not require an API key; the binary is discovered via <code>PATH</code> and managed locations under <code>$XDG_DATA_HOME</code> / <code>$HOME</code></strong>
+- whisper_cpp (whisper-cli) <strong>does not require an API key; the binary is discovered via <code>PATH</code> and managed locations under <code> $XDG_DATA_HOME </code> / <code> $HOME </code> </strong>
 - custom providers use <code>transcription.custom.&lt;name&gt;.api_key</code>. Secret resolution prefers <code>file_env</code>, then <code>file</code>, then <code>env</code>. Empty/missing keys are allowed for no-auth local servers.
 
 #### Custom OpenAI-compatible providers

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,8 @@ use crate::paths::expand_tilde;
 use crate::transcription::DEFAULT_PROMPT;
 use anyhow::{anyhow, Context, Result};
 use jsonc_parser::{parse_to_serde_value, ParseOptions};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::env;
 use std::fs;
@@ -340,13 +341,13 @@ impl Default for FastVadConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TranscriptionProvider {
     WhisperCpp,
     Groq,
     Gemini,
     Parakeet,
+    Custom(String),
 }
 
 impl Default for TranscriptionProvider {
@@ -356,12 +357,51 @@ impl Default for TranscriptionProvider {
 }
 
 impl TranscriptionProvider {
-    pub fn label(&self) -> &'static str {
+    pub fn label(&self) -> Cow<'static, str> {
         match self {
-            TranscriptionProvider::WhisperCpp => "Local",
-            TranscriptionProvider::Groq => "Groq",
-            TranscriptionProvider::Gemini => "Gemini",
-            TranscriptionProvider::Parakeet => "Parakeet TDT",
+            TranscriptionProvider::WhisperCpp => Cow::Borrowed("Local"),
+            TranscriptionProvider::Groq => Cow::Borrowed("Groq"),
+            TranscriptionProvider::Gemini => Cow::Borrowed("Gemini"),
+            TranscriptionProvider::Parakeet => Cow::Borrowed("Parakeet TDT"),
+            TranscriptionProvider::Custom(name) => Cow::Owned(format!("Custom ({name})")),
+        }
+    }
+}
+
+impl Serialize for TranscriptionProvider {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let value = match self {
+            TranscriptionProvider::WhisperCpp => "whisper_cpp".to_string(),
+            TranscriptionProvider::Groq => "groq".to_string(),
+            TranscriptionProvider::Gemini => "gemini".to_string(),
+            TranscriptionProvider::Parakeet => "parakeet".to_string(),
+            TranscriptionProvider::Custom(name) => format!("custom.{name}"),
+        };
+        serializer.serialize_str(&value)
+    }
+}
+
+impl<'de> Deserialize<'de> for TranscriptionProvider {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        match value.as_str() {
+            "whisper_cpp" => Ok(TranscriptionProvider::WhisperCpp),
+            "groq" => Ok(TranscriptionProvider::Groq),
+            "gemini" => Ok(TranscriptionProvider::Gemini),
+            "parakeet" => Ok(TranscriptionProvider::Parakeet),
+            _ => value
+                .strip_prefix("custom.")
+                .filter(|name| !name.trim().is_empty())
+                .map(|name| TranscriptionProvider::Custom(name.to_string()))
+                .ok_or_else(|| {
+                    serde::de::Error::custom(format!("unknown transcription provider '{value}'"))
+                }),
         }
     }
 }
@@ -455,6 +495,142 @@ impl Default for ParakeetConfig {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CustomProviderKind {
+    #[serde(rename = "openai_audio_transcriptions")]
+    OpenAiAudioTranscriptions,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ValueSource {
+    pub env: Option<String>,
+    pub value: Option<String>,
+}
+
+impl ValueSource {
+    pub fn resolve(&self, field_name: &str) -> Result<String> {
+        if let Some(env_name) = self
+            .env
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+        {
+            if let Ok(value) = env::var(env_name) {
+                let trimmed = value.trim();
+                if !trimmed.is_empty() {
+                    return Ok(trimmed.to_string());
+                }
+            }
+        }
+
+        if let Some(value) = self
+            .value
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return Ok(value.to_string());
+        }
+
+        Err(anyhow!("{field_name} is required"))
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SecretSource {
+    pub env: Option<String>,
+    pub file: Option<String>,
+    pub file_env: Option<String>,
+}
+
+impl SecretSource {
+    pub fn resolve(&self, field_name: &str) -> Result<Option<String>> {
+        if let Some(env_name) = self
+            .file_env
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+        {
+            if let Ok(path) = env::var(env_name) {
+                let trimmed = path.trim();
+                if !trimmed.is_empty() {
+                    return Self::read_secret_file(trimmed, field_name).map(Some);
+                }
+            }
+        }
+
+        if let Some(path) = self
+            .file
+            .as_deref()
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+        {
+            return Self::read_secret_file(path, field_name).map(Some);
+        }
+
+        if let Some(env_name) = self
+            .env
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+        {
+            if let Ok(value) = env::var(env_name) {
+                let trimmed = value.trim();
+                if !trimmed.is_empty() {
+                    return Ok(Some(trimmed.to_string()));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn read_secret_file(path: &str, field_name: &str) -> Result<String> {
+        let value = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {field_name} secret file: {path}"))?;
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err(anyhow!("{field_name} secret file is empty: {path}"));
+        }
+        Ok(trimmed.to_string())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct CustomProviderConfig {
+    pub kind: CustomProviderKind,
+    pub label: Option<String>,
+    pub base_url: ValueSource,
+    pub endpoint: String,
+    pub model: String,
+    pub audio_format: String,
+    pub api_key: SecretSource,
+    pub headers: HashMap<String, String>,
+    pub body: HashMap<String, String>,
+    pub prompt: String,
+}
+
+impl Default for CustomProviderConfig {
+    fn default() -> Self {
+        Self {
+            kind: CustomProviderKind::OpenAiAudioTranscriptions,
+            label: None,
+            base_url: ValueSource::default(),
+            endpoint: "/v1/audio/transcriptions".to_string(),
+            model: String::new(),
+            audio_format: "wav".to_string(),
+            api_key: SecretSource::default(),
+            headers: HashMap::new(),
+            body: HashMap::new(),
+            prompt: default_whisper_prompt(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct TranscriptionConfig {
@@ -465,6 +641,7 @@ pub struct TranscriptionConfig {
     pub groq: GroqConfig,
     pub gemini: GeminiConfig,
     pub parakeet: ParakeetConfig,
+    pub custom: HashMap<String, CustomProviderConfig>,
 }
 
 impl Default for TranscriptionConfig {
@@ -477,6 +654,7 @@ impl Default for TranscriptionConfig {
             groq: GroqConfig::default(),
             gemini: GeminiConfig::default(),
             parakeet: ParakeetConfig::default(),
+            custom: HashMap::new(),
         }
     }
 }

--- a/src/transcription/audio.rs
+++ b/src/transcription/audio.rs
@@ -17,10 +17,28 @@ pub struct EncodedAudio {
 /// codecs (e.g. Opus) offer smaller payloads but cause hallucinations in tests with
 /// both Groq Whisper and Gemini 2.5 Pro Flash, so we stick with FLAC here.
 pub async fn encode_to_flac(audio: &[f32]) -> Result<EncodedAudio> {
+    encode_with_ffmpeg(audio, "flac", "audio/flac", &["-compression_level", "12"]).await
+}
+
+/// Encodes raw PCM audio (mono, 16 kHz, f32 samples) into WAV.
+///
+/// whisper.cpp's server accepts WAV uploads by default. Custom OpenAI-compatible
+/// endpoints use this unless configured otherwise so local server setups do not
+/// require ffmpeg-side conversion on the server.
+pub async fn encode_to_wav(audio: &[f32]) -> Result<EncodedAudio> {
+    encode_with_ffmpeg(audio, "wav", "audio/wav", &[]).await
+}
+
+async fn encode_with_ffmpeg(
+    audio: &[f32],
+    format: &'static str,
+    content_type: &'static str,
+    extra_args: &[&str],
+) -> Result<EncodedAudio> {
     if audio.is_empty() {
         return Ok(EncodedAudio {
             data: Bytes::new(),
-            content_type: "audio/flac",
+            content_type,
         });
     }
 
@@ -36,10 +54,9 @@ pub async fn encode_to_flac(audio: &[f32]) -> Result<EncodedAudio> {
         .arg("1")
         .arg("-i")
         .arg("pipe:0")
-        .arg("-compression_level")
-        .arg("12")
+        .args(extra_args)
         .arg("-f")
-        .arg("flac")
+        .arg(format)
         .arg("pipe:1")
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
@@ -125,13 +142,14 @@ pub async fn encode_to_flac(audio: &[f32]) -> Result<EncodedAudio> {
     }
 
     debug!(
-        "Encoded PCM into FLAC ({} bytes -> {} bytes)",
+        "Encoded PCM into {} ({} bytes -> {} bytes)",
+        format,
         audio.len() * std::mem::size_of::<f32>(),
         encoded.len()
     );
 
     Ok(EncodedAudio {
         data: encoded,
-        content_type: "audio/flac",
+        content_type,
     })
 }

--- a/src/transcription/custom_openai.rs
+++ b/src/transcription/custom_openai.rs
@@ -34,8 +34,12 @@ impl CustomOpenAiTranscriber {
         max_retries: u32,
         prompt: String,
     ) -> Result<Self> {
-        let base_url = config.base_url.resolve("base_url")?;
-        let endpoint = resolve_endpoint(&base_url, &config.endpoint)?;
+        let endpoint = if is_absolute_endpoint(&config.endpoint) {
+            resolve_endpoint(None, &config.endpoint)?
+        } else {
+            let base_url = config.base_url.resolve("base_url")?;
+            resolve_endpoint(Some(&base_url), &config.endpoint)?
+        };
         let api_key = config.api_key.resolve("api_key")?;
 
         let client = Client::builder()
@@ -266,12 +270,17 @@ impl AudioFormat {
     }
 }
 
-fn resolve_endpoint(base_url: &str, endpoint: &str) -> Result<Url> {
-    if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
+fn is_absolute_endpoint(endpoint: &str) -> bool {
+    endpoint.starts_with("http://") || endpoint.starts_with("https://")
+}
+
+fn resolve_endpoint(base_url: Option<&str>, endpoint: &str) -> Result<Url> {
+    if is_absolute_endpoint(endpoint) {
         return Url::parse(endpoint)
             .with_context(|| format!("Invalid custom endpoint: {endpoint}"));
     }
 
+    let base_url = base_url.ok_or_else(|| anyhow::anyhow!("base_url is required"))?;
     let mut base = Url::parse(base_url)
         .with_context(|| format!("Invalid custom provider base_url: {base_url}"))?;
     if !base.path().ends_with('/') {

--- a/src/transcription/custom_openai.rs
+++ b/src/transcription/custom_openai.rs
@@ -1,0 +1,305 @@
+use crate::config::CustomProviderConfig;
+use crate::transcription::audio::{encode_to_flac, encode_to_wav, EncodedAudio};
+use crate::transcription::postprocess::clean_transcription;
+use crate::transcription::{BackendMetrics, TranscriptionResult};
+use anyhow::{Context, Result};
+use reqwest::{header, multipart, Client, Url};
+use serde::Deserialize;
+use std::cmp;
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+use tracing::{info, warn};
+
+#[derive(Clone)]
+pub struct CustomOpenAiTranscriber {
+    name: String,
+    label: String,
+    client: Client,
+    endpoint: Url,
+    api_key: Option<String>,
+    model: String,
+    audio_format: AudioFormat,
+    headers: Vec<(String, String)>,
+    body: Vec<(String, String)>,
+    prompt: String,
+    request_timeout: Duration,
+    max_retries: u32,
+}
+
+impl CustomOpenAiTranscriber {
+    pub fn new(
+        name: &str,
+        config: &CustomProviderConfig,
+        request_timeout: Duration,
+        max_retries: u32,
+        prompt: String,
+    ) -> Result<Self> {
+        let base_url = config.base_url.resolve("base_url")?;
+        let endpoint = resolve_endpoint(&base_url, &config.endpoint)?;
+        let api_key = config.api_key.resolve("api_key")?;
+
+        let client = Client::builder()
+            .user_agent(format!("hyprwhspr-rs (custom:{name})"))
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(request_timeout)
+            .pool_idle_timeout(Duration::from_secs(30))
+            .build()
+            .context("Failed to build custom OpenAI-compatible HTTP client")?;
+
+        Ok(Self {
+            name: name.to_string(),
+            label: config
+                .label
+                .clone()
+                .unwrap_or_else(|| format!("Custom ({name})")),
+            client,
+            endpoint,
+            api_key,
+            model: config.model.clone(),
+            audio_format: AudioFormat::from_config(&config.audio_format)?,
+            headers: config
+                .headers
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect(),
+            body: config
+                .body
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect(),
+            prompt,
+            request_timeout,
+            max_retries,
+        })
+    }
+
+    pub fn initialize(&self) -> Result<()> {
+        if self.model.trim().is_empty() {
+            anyhow::bail!(
+                "model is required for custom transcription provider '{}'",
+                self.name
+            );
+        }
+
+        info!(
+            "✅ {} transcription ready (model: {}, endpoint: {}, timeout: {:?})",
+            self.label, self.model, self.endpoint, self.request_timeout
+        );
+        Ok(())
+    }
+
+    pub fn provider_name(&self) -> &str {
+        &self.label
+    }
+
+    pub async fn transcribe(&self, audio_data: Vec<f32>) -> Result<TranscriptionResult> {
+        if audio_data.is_empty() {
+            return Ok(TranscriptionResult {
+                text: String::new(),
+                metrics: BackendMetrics::default(),
+            });
+        }
+
+        let duration_secs = audio_data.len() as f32 / 16000.0;
+        info!(
+            provider = self.provider_name(),
+            "🧠 Transcribing {:.2}s of audio via custom OpenAI-compatible provider", duration_secs
+        );
+
+        let encode_start = Instant::now();
+        let encoded = match self.audio_format {
+            AudioFormat::Wav => encode_to_wav(&audio_data).await?,
+            AudioFormat::Flac => encode_to_flac(&audio_data).await?,
+        };
+        let encode_duration = encode_start.elapsed();
+        let encoded_len = encoded.data.len();
+
+        let transcribe_start = Instant::now();
+        let (raw, timings) = self.send_with_retry(&encoded).await?;
+        let transcription_duration = transcribe_start.elapsed();
+        let cleaned = clean_transcription(&raw, &self.prompt);
+
+        if cleaned.is_empty() {
+            warn!("{} returned empty or non-speech transcription", self.label);
+        } else {
+            info!("✅ Transcription ({}): {}", self.label, cleaned);
+        }
+
+        let metrics = BackendMetrics {
+            encode_duration: Some(encode_duration),
+            encoded_bytes: Some(encoded_len),
+            upload_duration: Some(timings.upload),
+            response_duration: Some(timings.response),
+            transcription_duration,
+        };
+
+        Ok(TranscriptionResult {
+            text: cleaned,
+            metrics,
+        })
+    }
+
+    async fn send_with_retry(&self, audio: &EncodedAudio) -> Result<(String, NetworkTimings)> {
+        let attempts = cmp::max(1, self.max_retries.saturating_add(1));
+
+        for attempt in 0..attempts {
+            match self.send_once(audio).await {
+                Ok(result) => return Ok(result),
+                Err(err) => {
+                    if attempt + 1 == attempts {
+                        return Err(err);
+                    }
+
+                    warn!(
+                        attempt = attempt + 1,
+                        max_attempts = attempts,
+                        "Custom transcription attempt failed: {}",
+                        err
+                    );
+
+                    let backoff = Duration::from_millis(500 * (1 << attempt));
+                    sleep(backoff).await;
+                }
+            }
+        }
+
+        Err(anyhow::anyhow!("Unknown custom transcription failure"))
+    }
+
+    async fn send_once(&self, audio: &EncodedAudio) -> Result<(String, NetworkTimings)> {
+        let mut form = multipart::Form::new()
+            .text("model", self.model.clone())
+            .text("response_format", "json".to_string());
+
+        for (key, value) in &self.body {
+            form = form.text(key.clone(), value.clone());
+        }
+
+        if !self.prompt.trim().is_empty() && !self.body.iter().any(|(key, _)| key == "prompt") {
+            form = form.text("prompt", self.prompt.clone());
+        }
+
+        let file_part = multipart::Part::stream(audio.data.clone())
+            .file_name(self.audio_format.file_name())
+            .mime_str(audio.content_type)
+            .context("Failed to set custom provider audio content type")?;
+
+        form = form.part("file", file_part);
+
+        let mut request = self.client.post(self.endpoint.clone()).multipart(form);
+        let mut has_authorization = false;
+
+        for (key, value) in &self.headers {
+            if key.eq_ignore_ascii_case(header::AUTHORIZATION.as_str()) {
+                has_authorization = true;
+            }
+            request = request.header(key, value);
+        }
+
+        if let Some(api_key) = &self.api_key {
+            if !has_authorization {
+                request = request.bearer_auth(api_key);
+            }
+        }
+
+        let request_start = Instant::now();
+        let response = request
+            .send()
+            .await
+            .context("Failed to send custom transcription request")?;
+
+        let upload_duration = request_start.elapsed();
+
+        if response.status().is_success() {
+            let parse_start = Instant::now();
+            let payload: OpenAiTranscriptionResponse = response
+                .json()
+                .await
+                .context("Failed to deserialize custom transcription response")?;
+            let response_duration = parse_start.elapsed();
+            return Ok((
+                payload.text.unwrap_or_default(),
+                NetworkTimings {
+                    upload: upload_duration,
+                    response: response_duration,
+                },
+            ));
+        }
+
+        let status = response.status();
+        let body = response
+            .json::<OpenAiErrorResponse>()
+            .await
+            .unwrap_or_default();
+
+        let message = body
+            .error
+            .and_then(|err| err.message)
+            .unwrap_or_else(|| format!("Custom transcription failed with status {status}"));
+
+        Err(anyhow::anyhow!(message).context(format!("Custom request failed ({status})")))
+    }
+}
+
+#[derive(Clone, Copy)]
+enum AudioFormat {
+    Wav,
+    Flac,
+}
+
+impl AudioFormat {
+    fn from_config(value: &str) -> Result<Self> {
+        match value.trim() {
+            "" | "wav" => Ok(Self::Wav),
+            "flac" => Ok(Self::Flac),
+            other => anyhow::bail!(
+                "unsupported custom provider audio_format '{other}' (supported: wav, flac)"
+            ),
+        }
+    }
+
+    fn file_name(self) -> &'static str {
+        match self {
+            Self::Wav => "audio.wav",
+            Self::Flac => "audio.flac",
+        }
+    }
+}
+
+fn resolve_endpoint(base_url: &str, endpoint: &str) -> Result<Url> {
+    if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
+        return Url::parse(endpoint)
+            .with_context(|| format!("Invalid custom endpoint: {endpoint}"));
+    }
+
+    let mut base = Url::parse(base_url)
+        .with_context(|| format!("Invalid custom provider base_url: {base_url}"))?;
+    if !base.path().ends_with('/') {
+        let path = format!("{}/", base.path());
+        base.set_path(&path);
+    }
+
+    base.join(endpoint.trim_start_matches('/'))
+        .with_context(|| format!("Invalid custom provider endpoint: {endpoint}"))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NetworkTimings {
+    upload: Duration,
+    response: Duration,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct OpenAiTranscriptionResponse {
+    text: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct OpenAiErrorResponse {
+    error: Option<OpenAiErrorDetail>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct OpenAiErrorDetail {
+    message: Option<String>,
+}

--- a/src/transcription/mod.rs
+++ b/src/transcription/mod.rs
@@ -1,4 +1,5 @@
 mod audio;
+mod custom_openai;
 mod gemini;
 mod groq;
 #[cfg(feature = "parakeet")]
@@ -6,7 +7,7 @@ mod parakeet;
 mod postprocess;
 mod prompt;
 
-use crate::config::{Config, ConfigManager, TranscriptionProvider};
+use crate::config::{Config, ConfigManager, CustomProviderKind, TranscriptionProvider};
 #[cfg(feature = "parakeet")]
 use crate::paths::expand_tilde;
 use crate::whisper::{WhisperManager, WhisperVadOptions};
@@ -16,7 +17,8 @@ use anyhow::{Context, Result};
 use std::env;
 use std::time::Duration;
 
-pub use audio::{encode_to_flac, EncodedAudio};
+pub use audio::{encode_to_flac, encode_to_wav, EncodedAudio};
+pub use custom_openai::CustomOpenAiTranscriber;
 pub use gemini::GeminiTranscriber;
 pub use groq::GroqTranscriber;
 #[cfg(feature = "parakeet")]
@@ -28,6 +30,7 @@ pub enum TranscriptionBackend {
     Whisper(WhisperManager),
     Groq(GroqTranscriber),
     Gemini(GeminiTranscriber),
+    CustomOpenAi(CustomOpenAiTranscriber, String),
     #[cfg(feature = "parakeet")]
     Parakeet(ParakeetTranscriber),
 }
@@ -56,9 +59,9 @@ impl TranscriptionBackend {
         let timeout = Duration::from_secs(config.transcription.request_timeout_secs.max(5));
         let retries = config.transcription.max_retries;
 
-        match config.transcription.provider {
+        match &config.transcription.provider {
             TranscriptionProvider::WhisperCpp => {
-                let prompt = Self::prompt_for(config, TranscriptionProvider::WhisperCpp);
+                let prompt = Self::prompt_for(config, &TranscriptionProvider::WhisperCpp);
                 let whisper_cfg = &config.transcription.whisper_cpp;
                 let whisper_binaries =
                     config_manager.get_whisper_binary_candidates(whisper_cfg.fallback_cli);
@@ -75,7 +78,7 @@ impl TranscriptionBackend {
                 Ok(Self::Whisper(manager))
             }
             TranscriptionProvider::Groq => {
-                let prompt = Self::prompt_for(config, TranscriptionProvider::Groq);
+                let prompt = Self::prompt_for(config, &TranscriptionProvider::Groq);
                 let api_key = env::var("GROQ_API_KEY")
                     .context("GROQ_API_KEY environment variable is not set")?;
                 let provider = GroqTranscriber::new(
@@ -88,7 +91,7 @@ impl TranscriptionBackend {
                 Ok(Self::Groq(provider))
             }
             TranscriptionProvider::Gemini => {
-                let prompt = Self::prompt_for(config, TranscriptionProvider::Gemini);
+                let prompt = Self::prompt_for(config, &TranscriptionProvider::Gemini);
                 let api_key = env::var("GEMINI_API_KEY")
                     .context("GEMINI_API_KEY environment variable is not set")?;
                 let provider = GeminiTranscriber::new(
@@ -103,7 +106,7 @@ impl TranscriptionBackend {
             TranscriptionProvider::Parakeet => {
                 #[cfg(feature = "parakeet")]
                 {
-                    let prompt = Self::prompt_for(config, TranscriptionProvider::Parakeet);
+                    let prompt = Self::prompt_for(config, &TranscriptionProvider::Parakeet);
                     let par_cfg = &config.transcription.parakeet;
 
                     let expanded = expand_tilde(&par_cfg.model_dir);
@@ -123,6 +126,21 @@ impl TranscriptionBackend {
                     bail!("Parakeet backend is disabled in this build. Rebuild with --features parakeet.")
                 }
             }
+            TranscriptionProvider::Custom(name) => {
+                let custom_cfg = config.transcription.custom.get(name).ok_or_else(|| {
+                    anyhow::anyhow!("custom transcription provider '{name}' is not configured")
+                })?;
+                let prompt = Self::prompt_for(config, &TranscriptionProvider::Custom(name.clone()));
+
+                match custom_cfg.kind {
+                    CustomProviderKind::OpenAiAudioTranscriptions => {
+                        let provider = CustomOpenAiTranscriber::new(
+                            name, custom_cfg, timeout, retries, prompt,
+                        )?;
+                        Ok(Self::CustomOpenAi(provider, name.clone()))
+                    }
+                }
+            }
         }
     }
 
@@ -131,6 +149,7 @@ impl TranscriptionBackend {
             TranscriptionBackend::Whisper(manager) => manager.initialize(),
             TranscriptionBackend::Groq(provider) => provider.initialize(),
             TranscriptionBackend::Gemini(provider) => provider.initialize(),
+            TranscriptionBackend::CustomOpenAi(provider, _) => provider.initialize(),
             #[cfg(feature = "parakeet")]
             TranscriptionBackend::Parakeet(provider) => provider.initialize(),
         }
@@ -141,6 +160,9 @@ impl TranscriptionBackend {
             TranscriptionBackend::Whisper(_) => TranscriptionProvider::WhisperCpp,
             TranscriptionBackend::Groq(_) => TranscriptionProvider::Groq,
             TranscriptionBackend::Gemini(_) => TranscriptionProvider::Gemini,
+            TranscriptionBackend::CustomOpenAi(_, name) => {
+                TranscriptionProvider::Custom(name.clone())
+            }
             #[cfg(feature = "parakeet")]
             TranscriptionBackend::Parakeet(_) => TranscriptionProvider::Parakeet,
         }
@@ -151,7 +173,7 @@ impl TranscriptionBackend {
             return true;
         }
 
-        match new.transcription.provider {
+        match &new.transcription.provider {
             TranscriptionProvider::WhisperCpp => {
                 current.transcription.whisper_cpp != new.transcription.whisper_cpp
             }
@@ -159,20 +181,27 @@ impl TranscriptionBackend {
                 current.transcription.request_timeout_secs != new.transcription.request_timeout_secs
                     || current.transcription.max_retries != new.transcription.max_retries
                     || current.transcription.groq != new.transcription.groq
-                    || Self::prompt_for(current, TranscriptionProvider::Groq)
-                        != Self::prompt_for(new, TranscriptionProvider::Groq)
+                    || Self::prompt_for(current, &TranscriptionProvider::Groq)
+                        != Self::prompt_for(new, &TranscriptionProvider::Groq)
             }
             TranscriptionProvider::Gemini => {
                 current.transcription.request_timeout_secs != new.transcription.request_timeout_secs
                     || current.transcription.max_retries != new.transcription.max_retries
                     || current.transcription.gemini != new.transcription.gemini
-                    || Self::prompt_for(current, TranscriptionProvider::Gemini)
-                        != Self::prompt_for(new, TranscriptionProvider::Gemini)
+                    || Self::prompt_for(current, &TranscriptionProvider::Gemini)
+                        != Self::prompt_for(new, &TranscriptionProvider::Gemini)
             }
             TranscriptionProvider::Parakeet => {
                 current.transcription.parakeet != new.transcription.parakeet
-                    || Self::prompt_for(current, TranscriptionProvider::Parakeet)
-                        != Self::prompt_for(new, TranscriptionProvider::Parakeet)
+                    || Self::prompt_for(current, &TranscriptionProvider::Parakeet)
+                        != Self::prompt_for(new, &TranscriptionProvider::Parakeet)
+            }
+            TranscriptionProvider::Custom(name) => {
+                current.transcription.request_timeout_secs != new.transcription.request_timeout_secs
+                    || current.transcription.max_retries != new.transcription.max_retries
+                    || current.transcription.custom.get(name) != new.transcription.custom.get(name)
+                    || Self::prompt_for(current, &TranscriptionProvider::Custom(name.clone()))
+                        != Self::prompt_for(new, &TranscriptionProvider::Custom(name.clone()))
             }
         }
     }
@@ -182,6 +211,9 @@ impl TranscriptionBackend {
             TranscriptionBackend::Whisper(manager) => manager.transcribe(audio_data).await,
             TranscriptionBackend::Groq(provider) => provider.transcribe(audio_data).await,
             TranscriptionBackend::Gemini(provider) => provider.transcribe(audio_data).await,
+            TranscriptionBackend::CustomOpenAi(provider, _) => {
+                provider.transcribe(audio_data).await
+            }
             #[cfg(feature = "parakeet")]
             TranscriptionBackend::Parakeet(provider) => provider.transcribe(audio_data).await,
         }
@@ -189,7 +221,7 @@ impl TranscriptionBackend {
 }
 
 impl TranscriptionBackend {
-    fn prompt_for(config: &Config, provider: TranscriptionProvider) -> String {
+    fn prompt_for(config: &Config, provider: &TranscriptionProvider) -> String {
         match provider {
             TranscriptionProvider::WhisperCpp => {
                 PromptBlueprint::from(config.transcription.whisper_cpp.prompt.as_str()).resolve()
@@ -203,6 +235,12 @@ impl TranscriptionBackend {
             TranscriptionProvider::Parakeet => {
                 PromptBlueprint::from(config.transcription.parakeet.prompt.as_str()).resolve()
             }
+            TranscriptionProvider::Custom(name) => config
+                .transcription
+                .custom
+                .get(name)
+                .map(|custom| PromptBlueprint::from(custom.prompt.as_str()).resolve())
+                .unwrap_or_else(String::new),
         }
     }
 }

--- a/tests/custom_provider_config.rs
+++ b/tests/custom_provider_config.rs
@@ -1,0 +1,112 @@
+use hyprwhspr_rs::config::{
+    Config, CustomProviderKind, SecretSource, TranscriptionProvider, ValueSource,
+};
+
+#[test]
+fn custom_provider_config_deserializes_requested_shape() {
+    let json = r#"{
+        "transcription": {
+            "provider": "custom.remote_whisper",
+            "custom": {
+                "remote_whisper": {
+                    "kind": "openai_audio_transcriptions",
+                    "label": "Remote whisper.cpp",
+                    "base_url": {
+                        "env": "HYPRWHSPR_REMOTE_WHISPER_BASE_URL",
+                        "value": "http://localhost:8080"
+                    },
+                    "endpoint": "/v1/audio/transcriptions",
+                    "model": "whisper-large-v3",
+                    "api_key": {
+                        "env": "HYPRWHSPR_REMOTE_WHISPER_API_KEY",
+                        "file": "/run/secrets/hyprwhspr-remote-key",
+                        "file_env": "HYPRWHSPR_REMOTE_WHISPER_API_KEY_FILE"
+                    },
+                    "headers": {
+                        "x-provider": "whisper.cpp"
+                    },
+                    "body": {
+                        "temperature": "0",
+                        "response_format": "json"
+                    },
+                    "prompt": "Transcribe technical notes."
+                }
+            }
+        }
+    }"#;
+
+    let config: Config = serde_json::from_str(json).expect("deserialize config");
+
+    assert_eq!(
+        config.transcription.provider,
+        TranscriptionProvider::Custom("remote_whisper".to_string())
+    );
+
+    let custom = config
+        .transcription
+        .custom
+        .get("remote_whisper")
+        .expect("custom provider");
+
+    assert_eq!(custom.kind, CustomProviderKind::OpenAiAudioTranscriptions);
+    assert_eq!(custom.label.as_deref(), Some("Remote whisper.cpp"));
+    assert_eq!(
+        custom.base_url,
+        ValueSource {
+            env: Some("HYPRWHSPR_REMOTE_WHISPER_BASE_URL".to_string()),
+            value: Some("http://localhost:8080".to_string())
+        }
+    );
+    assert_eq!(custom.endpoint, "/v1/audio/transcriptions");
+    assert_eq!(custom.model, "whisper-large-v3");
+    assert_eq!(
+        custom.api_key,
+        SecretSource {
+            env: Some("HYPRWHSPR_REMOTE_WHISPER_API_KEY".to_string()),
+            file: Some("/run/secrets/hyprwhspr-remote-key".to_string()),
+            file_env: Some("HYPRWHSPR_REMOTE_WHISPER_API_KEY_FILE".to_string())
+        }
+    );
+    assert_eq!(
+        custom.headers.get("x-provider").map(String::as_str),
+        Some("whisper.cpp")
+    );
+    assert_eq!(
+        custom.body.get("temperature").map(String::as_str),
+        Some("0")
+    );
+    assert_eq!(custom.prompt, "Transcribe technical notes.");
+}
+
+#[test]
+fn custom_provider_round_trips() {
+    let mut config = Config::default();
+    config.transcription.provider = TranscriptionProvider::Custom("remote_whisper".to_string());
+    config.transcription.custom.insert(
+        "remote_whisper".to_string(),
+        hyprwhspr_rs::config::CustomProviderConfig {
+            kind: CustomProviderKind::OpenAiAudioTranscriptions,
+            label: Some("Remote whisper.cpp".to_string()),
+            base_url: ValueSource {
+                env: Some("HYPRWHSPR_REMOTE_WHISPER_BASE_URL".to_string()),
+                value: Some("http://localhost:8080".to_string()),
+            },
+            endpoint: "/v1/audio/transcriptions".to_string(),
+            model: "whisper-large-v3".to_string(),
+            audio_format: "wav".to_string(),
+            api_key: SecretSource {
+                env: Some("HYPRWHSPR_REMOTE_WHISPER_API_KEY".to_string()),
+                file: None,
+                file_env: Some("HYPRWHSPR_REMOTE_WHISPER_API_KEY_FILE".to_string()),
+            },
+            headers: [("x-provider".to_string(), "whisper.cpp".to_string())].into(),
+            body: [("response_format".to_string(), "json".to_string())].into(),
+            prompt: "Transcribe technical notes.".to_string(),
+        },
+    );
+
+    let json = serde_json::to_string_pretty(&config).expect("serialize config");
+    let decoded: Config = serde_json::from_str(&json).expect("deserialize config");
+
+    assert_eq!(decoded, config);
+}

--- a/tests/custom_provider_config.rs
+++ b/tests/custom_provider_config.rs
@@ -1,6 +1,9 @@
 use hyprwhspr_rs::config::{
-    Config, CustomProviderKind, SecretSource, TranscriptionProvider, ValueSource,
+    Config, CustomProviderConfig, CustomProviderKind, SecretSource, TranscriptionProvider,
+    ValueSource,
 };
+use hyprwhspr_rs::transcription::CustomOpenAiTranscriber;
+use std::time::Duration;
 
 #[test]
 fn custom_provider_config_deserializes_requested_shape() {
@@ -109,4 +112,23 @@ fn custom_provider_round_trips() {
     let decoded: Config = serde_json::from_str(&json).expect("deserialize config");
 
     assert_eq!(decoded, config);
+}
+
+#[test]
+fn custom_provider_allows_absolute_endpoint_without_base_url() {
+    let config = CustomProviderConfig {
+        kind: CustomProviderKind::OpenAiAudioTranscriptions,
+        label: Some("Fixed URL".to_string()),
+        base_url: ValueSource::default(),
+        endpoint: "http://127.0.0.1:18080/v1/audio/transcriptions".to_string(),
+        model: "whisper-large-v3".to_string(),
+        audio_format: "wav".to_string(),
+        api_key: SecretSource::default(),
+        headers: Default::default(),
+        body: Default::default(),
+        prompt: String::new(),
+    };
+
+    CustomOpenAiTranscriber::new("fixed_url", &config, Duration::from_secs(5), 0, String::new())
+        .expect("absolute endpoint should not require base_url");
 }

--- a/tests/custom_provider_sources.rs
+++ b/tests/custom_provider_sources.rs
@@ -1,0 +1,79 @@
+use hyprwhspr_rs::config::{SecretSource, ValueSource};
+
+#[test]
+fn value_source_prefers_non_empty_env_over_config_value() {
+    std::env::set_var("HYPRWHSPR_TEST_BASE_URL_PREFERS_ENV", "http://remote:8080");
+
+    let source = ValueSource {
+        env: Some("HYPRWHSPR_TEST_BASE_URL_PREFERS_ENV".to_string()),
+        value: Some("http://localhost:8080".to_string()),
+    };
+
+    assert_eq!(
+        source.resolve("base_url").expect("resolved base_url"),
+        "http://remote:8080"
+    );
+
+    std::env::remove_var("HYPRWHSPR_TEST_BASE_URL_PREFERS_ENV");
+}
+
+#[test]
+fn value_source_uses_config_value_when_env_is_unset() {
+    std::env::remove_var("HYPRWHSPR_TEST_BASE_URL_USES_VALUE");
+
+    let source = ValueSource {
+        env: Some("HYPRWHSPR_TEST_BASE_URL_USES_VALUE".to_string()),
+        value: Some("http://localhost:8080".to_string()),
+    };
+
+    assert_eq!(
+        source.resolve("base_url").expect("resolved base_url"),
+        "http://localhost:8080"
+    );
+}
+
+#[test]
+fn secret_source_prefers_file_env_then_file_then_env() {
+    let root =
+        std::env::temp_dir().join(format!("hyprwhspr-rs-secret-source-{}", std::process::id()));
+    std::fs::create_dir_all(&root).expect("create temp dir");
+    let file_env_path = root.join("file-env-secret");
+    let file_path = root.join("file-secret");
+    std::fs::write(&file_env_path, "from-file-env\n").expect("write file env secret");
+    std::fs::write(&file_path, "from-file\n").expect("write file secret");
+
+    std::env::set_var("HYPRWHSPR_TEST_API_KEY_FILE", &file_env_path);
+    std::env::set_var("HYPRWHSPR_TEST_API_KEY", "from-env");
+
+    let source = SecretSource {
+        env: Some("HYPRWHSPR_TEST_API_KEY".to_string()),
+        file: Some(file_path.to_string_lossy().into_owned()),
+        file_env: Some("HYPRWHSPR_TEST_API_KEY_FILE".to_string()),
+    };
+
+    assert_eq!(
+        source.resolve("api_key").expect("resolved api_key"),
+        Some("from-file-env".to_string())
+    );
+
+    std::env::remove_var("HYPRWHSPR_TEST_API_KEY_FILE");
+    assert_eq!(
+        source.resolve("api_key").expect("resolved api_key"),
+        Some("from-file".to_string())
+    );
+
+    let env_only_source = SecretSource {
+        env: Some("HYPRWHSPR_TEST_API_KEY".to_string()),
+        file: None,
+        file_env: None,
+    };
+    assert_eq!(
+        env_only_source
+            .resolve("api_key")
+            .expect("resolved api_key"),
+        Some("from-env".to_string())
+    );
+
+    std::env::remove_var("HYPRWHSPR_TEST_API_KEY");
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/tests/custom_whisper_cpp_server.rs
+++ b/tests/custom_whisper_cpp_server.rs
@@ -1,0 +1,109 @@
+//! Gated smoke test for a real whisper.cpp server.
+//!
+//! This test is ignored by default because it builds/runs an external server.
+//! To run it cheaply against an existing checkout/server binary:
+//!
+//! ```text
+//! HYPRWHSPR_WHISPER_CPP_SERVER=/tmp/whisper.cpp/build/bin/whisper-server \
+//! HYPRWHSPR_WHISPER_CPP_MODEL=/path/to/ggml-tiny.en.bin \
+//! cargo test --test custom_whisper_cpp_server -- --ignored
+//! ```
+
+use hyprwhspr_rs::config::{
+    Config, CustomProviderConfig, CustomProviderKind, TranscriptionProvider, ValueSource,
+};
+use hyprwhspr_rs::transcription::CustomOpenAiTranscriber;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+#[tokio::test]
+#[ignore = "requires whisper.cpp server binary and model env vars"]
+async fn custom_provider_transcribes_against_whisper_cpp_server() {
+    let server = std::env::var("HYPRWHSPR_WHISPER_CPP_SERVER")
+        .expect("HYPRWHSPR_WHISPER_CPP_SERVER must point to whisper-server");
+    let model = std::env::var("HYPRWHSPR_WHISPER_CPP_MODEL")
+        .expect("HYPRWHSPR_WHISPER_CPP_MODEL must point to a ggml model");
+    let port = std::env::var("HYPRWHSPR_WHISPER_CPP_PORT").unwrap_or_else(|_| "18080".to_string());
+    let base_url = format!("http://127.0.0.1:{port}");
+
+    let mut child = spawn_server(&server, &model, &port);
+    wait_for_server(&base_url).await;
+
+    let mut config = Config::default();
+    config.transcription.provider = TranscriptionProvider::Custom("remote_whisper".to_string());
+    config.transcription.custom.insert(
+        "remote_whisper".to_string(),
+        CustomProviderConfig {
+            kind: CustomProviderKind::OpenAiAudioTranscriptions,
+            label: Some("Remote whisper.cpp".to_string()),
+            base_url: ValueSource {
+                env: None,
+                value: Some(base_url),
+            },
+            endpoint: "/v1/audio/transcriptions".to_string(),
+            model: "whisper-large-v3".to_string(),
+            audio_format: "wav".to_string(),
+            api_key: Default::default(),
+            headers: Default::default(),
+            body: Default::default(),
+            prompt: String::new(),
+        },
+    );
+
+    let custom = config
+        .transcription
+        .custom
+        .get("remote_whisper")
+        .expect("custom provider");
+    let transcriber = CustomOpenAiTranscriber::new(
+        "remote_whisper",
+        custom,
+        Duration::from_secs(30),
+        0,
+        String::new(),
+    )
+    .expect("custom transcriber");
+
+    let mut audio = Vec::new();
+    for i in 0..16_000 {
+        let t = i as f32 / 16_000.0;
+        audio.push((t * 440.0 * std::f32::consts::TAU).sin() * 0.1);
+    }
+
+    let result = transcriber.transcribe(audio).await.expect("transcribe");
+    assert!(result.text.trim().is_empty() || !result.text.contains("error"));
+
+    let _ = child.kill();
+}
+
+fn spawn_server(server: &str, model: &str, port: &str) -> Child {
+    Command::new(server)
+        .args([
+            "--host",
+            "127.0.0.1",
+            "--port",
+            port,
+            "--inference-path",
+            "/v1/audio/transcriptions",
+            "-m",
+            model,
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn whisper.cpp server")
+}
+
+async fn wait_for_server(base_url: &str) {
+    let client = reqwest::Client::new();
+    let deadline = Instant::now() + Duration::from_secs(20);
+
+    while Instant::now() < deadline {
+        if client.get(base_url).send().await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    panic!("whisper.cpp server did not become ready");
+}


### PR DESCRIPTION
Adds custom providers, namely openai compatible ones. Respects old config but adds a `transcription.custom.<custom name>` configuration option:

```jsonc ~/.config/hyprwhspr-rs/config.jsonc
"transcription": {
  "provider": "custom.my_remote_whisper",
  "custom": {
    "my_remote_whisper": {
      "kind": "openai_audio_transcriptions",
      "label": "My remote whisper.cpp",
      "base_url": {
        "env": "HYPRWHSPR_MY_REMOTE_WHISPER_BASE_URL",
        "value": "http://localhost:8080"
      },
      "endpoint": "/v1/audio/transcriptions",
      "model": "whisper-large-v3",
      "api_key": {
        "env": "HYPRWHSPR_MY_REMOTE_WHISPER_API_KEY",
        "file": "/run/secrets/hyprwhspr-remote-key",
        "file_env": "HYPRWHSPR_MY_REMOTE_WHISPER_API_KEY_FILE"
      },
      "audio_format": "wav",
      "headers": {
        "authorization": "Bearer sk-...",
        "x-provider": "whisper.cpp",
        "x-client": "hyprwhspr-rs",
      },
      "body": {
        "temperature": "0.3",
        "response_format": "json"
       },
      "prompt": "Transcribe technical notes."
    }
  }
}
```

closes #129
