### PR TITLE
feat(config): add versioned schema + bump openssl to 0.10.80

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "earshot"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,6 +1249,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rodio",
+ "schemars",
  "serde",
  "serde_json",
  "similar",
@@ -2582,6 +2589,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2776,6 +2803,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2834,6 +2886,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
@@ -2155,9 +2155,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ tokio = { version = "1", features = ["io-std", "io-util", "macros", "net", "proc
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 jsonc-parser = { version = "0.26.3", features = ["serde"] }
+schemars = "1"
 
 # HTTP & async utilities
 reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }

--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ With NixOS:
 ```
 
 ## Configuration
+
+In `~/.config/hyprwhspr-rs/config.jsonc`, you may use `"$schema": "https://raw.githubusercontent.com/better-slop/hyprwhspr-rs/<vX.X.X|main>/config/schema.json"` to validate your config.
+
 <details>
     <summary>
         <strong>Example hyprland bindings config</strong>

--- a/README.md
+++ b/README.md
@@ -104,16 +104,17 @@ Notes:
 You can install the `hyprwhspr-rs` package from nixpkgs.
 
 With NixOS:
+
 ```nix
 {
   # required to listen for keyboard shortcuts
   users.users.<username>.extraGroups = [ "input" ];
-  
+
   # have it auto start as a systemd unit with
-  services.hyprwhspr-rs.enable = true; 
+  services.hyprwhspr-rs.enable = true;
   # or just add it to your systemPackages
   environment.systemPackages = [ pkgs.hyprwhspr-rs ];
-  
+
   # optional: to enable cuda (for AMD do `rocmSupport` instead of `cudaSupport`)
   # cuda is unfree so not in the default nixos build caches
   # I highly recommend adding the cuda build cache to your nixconfig https://discourse.nixos.org/t/cuda-cache-for-nix-community/56038
@@ -122,13 +123,13 @@ With NixOS:
     package = pkgs.hyprwhspr-rs.override {
       # to optimize build time you can skip enabling cudaSupport for one of these two
       # for whisper do whisper-cpp, for NVIDIA Parakeet do onnxruntime
-      whispercpp = pkgs.whisper-cpp.override { cudaSupport = true; }; 
+      whispercpp = pkgs.whisper-cpp.override { cudaSupport = true; };
       onnxruntime = pkgs.onnxruntime.override { cudaSupport = true; };
     };
   };
   # you can also enable cuda/rocm globally, but this will increase the build time for your entire system if you dont add the cuda build cache
   nixpkgs.config.cudaSupport = true;
-  
+
   # if you use groq or gemini for transcription, you can autoload their keys with
   services.hyprwhspr-rs = {
     enable = true;
@@ -153,12 +154,11 @@ With NixOS:
 
 ## Configuration
 
-In `~/.config/hyprwhspr-rs/config.jsonc`, you may use `"$schema": "https://raw.githubusercontent.com/better-slop/hyprwhspr-rs/<vX.X.X|main>/config/schema.json"` to validate your config.
-
 <details>
     <summary>
         <strong>Example hyprland bindings config</strong>
         <p>Configure in, e.g., ~/.config/hypr/hyprland.conf</p>
+        <p>Starting with `v0.28.0`, you may use `"$schema": "https://raw.githubusercontent.com/better-slop/hyprwhspr-rs/<vX.X.X|main>/config/schema.json"` to validate your config.</p>
     </summary>
 
 ```ini
@@ -169,6 +169,7 @@ bindr = ALT, GRAVE, exec, hyprwhspr-rs record stop
 # tap
 bind = ALT, SPACE, exec, hyprwhspr-rs record toggle
 ```
+
 </details>
 <details>
   <summary>

--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ recompiling.
 4. Run using:
    - pretty logs: `RUST_LOG=debug ./target/release/hyprwhspr-rs`
    - production release: `./target/release/hyprwhspr-rs`
+5. On schema changes, run `cargo run --bin generate-schema -- config/schema.json` and commit.
 
 <details>
   <summary>

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ bind = ALT, SPACE, exec, hyprwhspr-rs record toggle
 
 ```jsonc
 {
+  "$schema": "https://raw.githubusercontent.com/better-slop/hyprwhspr-rs/main/config/schema.json",
   "shortcuts": {
     "press": "SUPER+ALT+D",
     "hold": "SUPER+ALT+CTRL",

--- a/config/schema.json
+++ b/config/schema.json
@@ -1,0 +1,662 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Config",
+  "type": "object",
+  "properties": {
+    "audio_device": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint",
+      "default": null,
+      "minimum": 0
+    },
+    "audio_feedback": {
+      "type": "boolean",
+      "default": false
+    },
+    "auto_copy_clipboard": {
+      "type": "boolean",
+      "default": true
+    },
+    "fallback_cli": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "writeOnly": true
+    },
+    "fast_vad": {
+      "$ref": "#/$defs/FastVadConfig",
+      "default": {
+        "enabled": false,
+        "min_speech_ms": 120,
+        "post_roll_ms": 150,
+        "pre_roll_ms": 120,
+        "profile": "aggressive",
+        "silence_timeout_ms": 500,
+        "volatility_decrease_threshold": 0.11999999731779099,
+        "volatility_increase_threshold": 0.3499999940395355,
+        "volatility_window": 24
+      }
+    },
+    "global_paste_shortcut": {
+      "type": "boolean",
+      "default": false
+    },
+    "gpu_layers": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "int32",
+      "writeOnly": true
+    },
+    "model": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "writeOnly": true
+    },
+    "models_dirs": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      },
+      "writeOnly": true
+    },
+    "no_speech_threshold": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "format": "float",
+      "writeOnly": true
+    },
+    "paste_hints": {
+      "$ref": "#/$defs/PasteHintsConfig",
+      "default": {}
+    },
+    "primary_shortcut": {
+      "type": "string",
+      "writeOnly": true
+    },
+    "shift_paste": {
+      "type": "boolean",
+      "default": true
+    },
+    "shortcuts": {
+      "$ref": "#/$defs/ShortcutsConfig",
+      "default": {
+        "press": "SUPER+ALT+R"
+      }
+    },
+    "start_sound_path": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "default": null
+    },
+    "start_sound_volume": {
+      "type": "number",
+      "format": "float",
+      "default": 0.30000001192092896
+    },
+    "stop_sound_path": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "default": null
+    },
+    "stop_sound_volume": {
+      "type": "number",
+      "format": "float",
+      "default": 0.30000001192092896
+    },
+    "threads": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint",
+      "minimum": 0,
+      "writeOnly": true
+    },
+    "transcription": {
+      "$ref": "#/$defs/TranscriptionConfig",
+      "default": {
+        "custom": {},
+        "gemini": {
+          "endpoint": "https://generativelanguage.googleapis.com/v1beta/models",
+          "max_output_tokens": 1024,
+          "model": "gemini-2.5-pro-exp-0827",
+          "prompt": "Transcribe with proper capitalization, including sentence beginnings, proper nouns, titles, and standard English capitalization rules.",
+          "temperature": 0.0
+        },
+        "groq": {
+          "endpoint": "https://api.groq.com/openai/v1/audio/transcriptions",
+          "model": "whisper-large-v3-turbo",
+          "prompt": "Transcribe with proper capitalization, including sentence beginnings, proper nouns, titles, and standard English capitalization rules."
+        },
+        "max_retries": 2,
+        "parakeet": {
+          "model_dir": "models/parakeet/parakeet-tdt-0.6b-v3-onnx",
+          "prompt": "Transcribe with proper capitalization, including sentence beginnings, proper nouns, titles, and standard English capitalization rules."
+        },
+        "provider": "whisper_cpp",
+        "request_timeout_secs": 45,
+        "whisper_cpp": {
+          "fallback_cli": false,
+          "gpu_layers": 999,
+          "model": "base",
+          "models_dirs": [
+            "~/.local/share/hyprwhspr-rs/models"
+          ],
+          "no_speech_threshold": 0.6000000238418579,
+          "prompt": "Transcribe with proper capitalization, including sentence beginnings, proper nouns, titles, and standard English capitalization rules.",
+          "threads": 4,
+          "vad": {
+            "enabled": false,
+            "min_silence_ms": 100,
+            "min_speech_ms": 250,
+            "model": "ggml-silero-v5.1.2.bin",
+            "samples_overlap": 0.10000000149011612,
+            "speech_pad_ms": 30,
+            "threshold": 0.5
+          }
+        }
+      }
+    },
+    "vad": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/VadConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "writeOnly": true
+    },
+    "whisper_prompt": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "writeOnly": true
+    },
+    "word_overrides": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    }
+  },
+  "$defs": {
+    "CustomProviderConfig": {
+      "type": "object",
+      "properties": {
+        "api_key": {
+          "$ref": "#/$defs/SecretSource",
+          "default": {
+            "env": null,
+            "file": null,
+            "file_env": null
+          }
+        },
+        "audio_format": {
+          "type": "string",
+          "default": "wav"
+        },
+        "base_url": {
+          "$ref": "#/$defs/ValueSource",
+          "default": {
+            "env": null,
+            "value": null
+          }
+        },
+        "body": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        },
+        "endpoint": {
+          "type": "string",
+          "default": "/v1/audio/transcriptions"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
+        },
+        "kind": {
+          "$ref": "#/$defs/CustomProviderKind",
+          "default": "openai_audio_transcriptions"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "model": {
+          "type": "string",
+          "default": ""
+        },
+        "prompt": {
+          "type": "string",
+          "default": "Transcribe with proper capitalization, including sentence beginnings, proper nouns, titles, and standard English capitalization rules."
+        }
+      }
+    },
+    "CustomProviderKind": {
+      "type": "string",
+      "enum": [
+        "openai_audio_transcriptions"
+      ]
+    },
+    "FastVadConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "min_speech_ms": {
+          "type": "integer",
+          "format": "uint32",
+          "default": 120,
+          "minimum": 0
+        },
+        "post_roll_ms": {
+          "type": "integer",
+          "format": "uint32",
+          "default": 150,
+          "minimum": 0
+        },
+        "pre_roll_ms": {
+          "type": "integer",
+          "format": "uint32",
+          "default": 120,
+          "minimum": 0
+        },
+        "profile": {
+          "$ref": "#/$defs/FastVadProfileConfig",
+          "default": "aggressive"
+        },
+        "silence_timeout_ms": {
+          "type": "integer",
+          "format": "uint32",
+          "default": 500,
+          "minimum": 0
+        },
+        "volatility_decrease_threshold": {
+          "type": "number",
+          "format": "float",
+          "default": 0.11999999731779099
+        },
+        "volatility_increase_threshold": {
+          "type": "number",
+          "format": "float",
+          "default": 0.3499999940395355
+        },
+        "volatility_window": {
+          "type": "integer",
+          "format": "uint32",
+          "default": 24,
+          "minimum": 0
+        }
+      }
+    },
+    "FastVadProfileConfig": {
+      "type": "string",
+      "enum": [
+        "quality",
+        "low_bitrate",
+        "aggressive",
+        "very_aggressive"
+      ]
+    },
+    "GeminiConfig": {
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "type": "string",
+          "default": "https://generativelanguage.googleapis.com/v1beta/models"
+        },
+        "max_output_tokens": {
+          "type": "integer",
+          "format": "uint32",
+          "default": 1024,
+          "minimum": 0
+        },
+        "model": {
+          "type": "string",
+          "default": "gemini-2.5-pro-exp-0827"
+        },
+        "prompt": {
+          "type": "string",
+          "default": "Transcribe with proper capitalization, including sentence beginnings, proper nouns, titles, and standard English capitalization rules."
+        },
+        "temperature": {
+          "type": "number",
+          "format": "float",
+          "default": 0.0
+        }
+      }
+    },
+    "GroqConfig": {
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "type": "string",
+          "default": "https://api.groq.com/openai/v1/audio/transcriptions"
+        },
+        "model": {
+          "type": "string",
+          "default": "whisper-large-v3-turbo"
+        },
+        "prompt": {
+          "type": "string",
+          "default": "Transcribe with proper capitalization, including sentence beginnings, proper nouns, titles, and standard English capitalization rules."
+        }
+      }
+    },
+    "ParakeetConfig": {
+      "type": "object",
+      "properties": {
+        "model_dir": {
+          "type": "string",
+          "default": "models/parakeet/parakeet-tdt-0.6b-v3-onnx"
+        },
+        "prompt": {
+          "type": "string",
+          "default": "Transcribe with proper capitalization, including sentence beginnings, proper nouns, titles, and standard English capitalization rules."
+        }
+      }
+    },
+    "PasteHintsConfig": {
+      "type": "object",
+      "properties": {
+        "shift": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "shift_insert": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "SecretSource": {
+      "type": "object",
+      "properties": {
+        "env": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "file": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "file_env": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        }
+      }
+    },
+    "ShortcutsConfig": {
+      "type": "object",
+      "properties": {
+        "hold": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "press": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "TranscriptionConfig": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/CustomProviderConfig"
+          },
+          "default": {}
+        },
+        "gemini": {
+          "$ref": "#/$defs/GeminiConfig",
+          "default": {
+            "endpoint": "https://generativelanguage.googleapis.com/v1beta/models",
+            "max_output_tokens": 1024,
+            "model": "gemini-2.5-pro-exp-0827",
+            "prompt": "Transcribe with proper capitalization, including sentence beginnings, proper nouns, titles, and standard English capitalization rules.",
+            "temperature": 0.0
+          }
+        },
+        "groq": {
+          "$ref": "#/$defs/GroqConfig",
+          "default": {
+            "endpoint": "https://api.groq.com/openai/v1/audio/transcriptions",
+            "model": "whisper-large-v3-turbo",
+            "prompt": "Transcribe with proper capitalization, including sentence beginnings, proper nouns, titles, and standard English capitalization rules."
+          }
+        },
+        "max_retries": {
+          "type": "integer",
+          "format": "uint32",
+          "default": 2,
+          "minimum": 0
+        },
+        "parakeet": {
+          "$ref": "#/$defs/ParakeetConfig",
+          "default": {
+            "model_dir": "models/parakeet/parakeet-tdt-0.6b-v3-onnx",
+            "prompt": "Transcribe with proper capitalization, including sentence beginnings, proper nouns, titles, and standard English capitalization rules."
+          }
+        },
+        "provider": {
+          "$ref": "#/$defs/TranscriptionProvider",
+          "default": "whisper_cpp"
+        },
+        "request_timeout_secs": {
+          "type": "integer",
+          "format": "uint64",
+          "default": 45,
+          "minimum": 0
+        },
+        "whisper_cpp": {
+          "$ref": "#/$defs/WhisperCppConfig",
+          "default": {
+            "fallback_cli": false,
+            "gpu_layers": 999,
+            "model": "base",
+            "models_dirs": [
+              "~/.local/share/hyprwhspr-rs/models"
+            ],
+            "no_speech_threshold": 0.6000000238418579,
+            "prompt": "Transcribe with proper capitalization, including sentence beginnings, proper nouns, titles, and standard English capitalization rules.",
+            "threads": 4,
+            "vad": {
+              "enabled": false,
+              "min_silence_ms": 100,
+              "min_speech_ms": 250,
+              "model": "ggml-silero-v5.1.2.bin",
+              "samples_overlap": 0.10000000149011612,
+              "speech_pad_ms": 30,
+              "threshold": 0.5
+            }
+          }
+        }
+      }
+    },
+    "TranscriptionProvider": {
+      "type": "string",
+      "anyOf": [
+        {
+          "enum": [
+            "whisper_cpp",
+            "groq",
+            "gemini",
+            "parakeet"
+          ]
+        },
+        {
+          "pattern": "^custom\\.[A-Za-z0-9_-]+$"
+        }
+      ]
+    },
+    "VadConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "max_speech_s": {
+          "type": "number",
+          "format": "float"
+        },
+        "min_silence_ms": {
+          "type": "integer",
+          "format": "uint32",
+          "default": 100,
+          "minimum": 0
+        },
+        "min_speech_ms": {
+          "type": "integer",
+          "format": "uint32",
+          "default": 250,
+          "minimum": 0
+        },
+        "model": {
+          "type": "string",
+          "default": "ggml-silero-v5.1.2.bin"
+        },
+        "samples_overlap": {
+          "type": "number",
+          "format": "float",
+          "default": 0.10000000149011612
+        },
+        "speech_pad_ms": {
+          "type": "integer",
+          "format": "uint32",
+          "default": 30,
+          "minimum": 0
+        },
+        "threshold": {
+          "type": "number",
+          "format": "float",
+          "default": 0.5
+        }
+      }
+    },
+    "ValueSource": {
+      "type": "object",
+      "properties": {
+        "env": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "value": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        }
+      }
+    },
+    "WhisperCppConfig": {
+      "type": "object",
+      "properties": {
+        "fallback_cli": {
+          "type": "boolean",
+          "default": false
+        },
+        "gpu_layers": {
+          "type": "integer",
+          "format": "int32",
+          "default": 999
+        },
+        "model": {
+          "type": "string",
+          "default": "base"
+        },
+        "models_dirs": {
+          "type": "array",
+          "default": [
+            "~/.local/share/hyprwhspr-rs/models"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "no_speech_threshold": {
+          "type": "number",
+          "format": "float",
+          "default": 0.6000000238418579
+        },
+        "prompt": {
+          "type": "string",
+          "default": "Transcribe with proper capitalization, including sentence beginnings, proper nouns, titles, and standard English capitalization rules."
+        },
+        "threads": {
+          "type": "integer",
+          "format": "uint",
+          "default": 4,
+          "minimum": 0
+        },
+        "vad": {
+          "$ref": "#/$defs/VadConfig",
+          "default": {
+            "enabled": false,
+            "min_silence_ms": 100,
+            "min_speech_ms": 250,
+            "model": "ggml-silero-v5.1.2.bin",
+            "samples_overlap": 0.10000000149011612,
+            "speech_pad_ms": 30,
+            "threshold": 0.5
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/bin/generate-schema.rs
+++ b/src/bin/generate-schema.rs
@@ -1,0 +1,22 @@
+use anyhow::{Context, Result};
+use hyprwhspr_rs::config::generated_schema_json;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+fn main() -> Result<()> {
+    let output_path = env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("config/schema.json"));
+
+    let schema = generated_schema_json()?;
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+    fs::write(&output_path, format!("{schema}\n"))
+        .with_context(|| format!("Failed to write {}", output_path.display()))?;
+
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use crate::paths::expand_tilde;
 use crate::transcription::DEFAULT_PROMPT;
 use anyhow::{anyhow, Context, Result};
 use jsonc_parser::{parse_to_serde_value, ParseOptions};
+use schemars::{json_schema, JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -14,7 +15,12 @@ use std::time::{Duration, SystemTime};
 use tokio::sync::watch;
 use tokio::time;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub fn generated_schema_json() -> Result<String> {
+    let schema = schemars::schema_for!(Config);
+    serde_json::to_string_pretty(&schema).context("Failed to serialize config JSON schema")
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct ShortcutsConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hold: Option<String>,
@@ -32,7 +38,7 @@ impl Default for ShortcutsConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(default)]
 pub struct PasteHintsConfig {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -51,7 +57,7 @@ impl Default for PasteHintsConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct Config {
     #[serde(default = "default_primary_shortcut", skip_serializing)]
     pub primary_shortcut: String,
@@ -263,7 +269,7 @@ fn default_fast_vad_volatility_decrease_threshold() -> f32 {
     0.12
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(default)]
 pub struct VadConfig {
     pub enabled: bool,
@@ -296,7 +302,7 @@ impl Default for VadConfig {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum FastVadProfileConfig {
     Quality,
@@ -311,7 +317,7 @@ impl Default for FastVadProfileConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(default)]
 pub struct FastVadConfig {
     pub enabled: bool,
@@ -406,7 +412,27 @@ impl<'de> Deserialize<'de> for TranscriptionProvider {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+impl JsonSchema for TranscriptionProvider {
+    fn schema_name() -> Cow<'static, str> {
+        "TranscriptionProvider".into()
+    }
+
+    fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "string",
+            "anyOf": [
+                {
+                    "enum": ["whisper_cpp", "groq", "gemini", "parakeet"]
+                },
+                {
+                    "pattern": "^custom\\.[A-Za-z0-9_-]+$"
+                }
+            ]
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(default)]
 pub struct WhisperCppConfig {
     pub prompt: String,
@@ -434,7 +460,7 @@ impl Default for WhisperCppConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(default)]
 pub struct GroqConfig {
     pub model: String,
@@ -452,7 +478,7 @@ impl Default for GroqConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(default)]
 pub struct GeminiConfig {
     pub model: String,
@@ -479,7 +505,7 @@ fn default_parakeet_model_dir() -> String {
     "models/parakeet/parakeet-tdt-0.6b-v3-onnx".to_string()
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(default)]
 pub struct ParakeetConfig {
     pub model_dir: String,
@@ -495,14 +521,14 @@ impl Default for ParakeetConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum CustomProviderKind {
     #[serde(rename = "openai_audio_transcriptions")]
     OpenAiAudioTranscriptions,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(default)]
 pub struct ValueSource {
     pub env: Option<String>,
@@ -538,7 +564,7 @@ impl ValueSource {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(default)]
 pub struct SecretSource {
     pub env: Option<String>,
@@ -599,7 +625,7 @@ impl SecretSource {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(default)]
 pub struct CustomProviderConfig {
     pub kind: CustomProviderKind,
@@ -631,7 +657,7 @@ impl Default for CustomProviderConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(default)]
 pub struct TranscriptionConfig {
     pub provider: TranscriptionProvider,

--- a/tests/config_serialization.rs
+++ b/tests/config_serialization.rs
@@ -1,6 +1,17 @@
 use hyprwhspr_rs::Config;
 
 #[test]
+fn checked_in_schema_is_current() {
+    let generated = format!(
+        "{}\n",
+        hyprwhspr_rs::config::generated_schema_json().expect("generate schema")
+    );
+    let checked_in = include_str!("../config/schema.json");
+
+    assert_eq!(checked_in, generated);
+}
+
+#[test]
 fn default_config_omits_infinite_max_speech_s() {
     let config = Config::default();
     let json = serde_json::to_string_pretty(&config).expect("serialize config");


### PR DESCRIPTION
Adds a generated json schema at `config/schema.json` for `config.jsonc`, with a `generate-schema` binary and drift test to keep it in sync with the Rust config types. Documents the raw GitHub `$schema` URL in the README, including support for the custom provider config shape. Also bumps `openssl` to `0.10.80`.