### PR TITLE
chore: release v0.3.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.3.29] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.28...v0.3.29) - 2026-05-26
+
+### Features
+- *(config)* add versioned schema + bump openssl to 0.10.80 ([#133](https://github.com/better-slop/hyprwhspr-rs/pull/133))
+
+
+### Fixes
+- allow null vad max speech in schema ([#135](https://github.com/better-slop/hyprwhspr-rs/pull/135))
+
 ## [0.3.28] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.27...v0.3.28) - 2026-05-25
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "hyprwhspr-rs"
-version = "0.3.28"
+version = "0.3.29"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyprwhspr-rs"
-version = "0.3.28"
+version = "0.3.29"
 edition = "2021"
 authors = ["hyprwhspr-rs contributors"]
 description = "Native speech-to-text voice dictation for Hyprland (Rust implementation)"


### PR DESCRIPTION



## 🤖 New release

* `hyprwhspr-rs`: 0.3.28 -> 0.3.29 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.29] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.28...v0.3.29) - 2026-05-26

### Features
- *(config)* add versioned schema + bump openssl to 0.10.80 ([#133](https://github.com/better-slop/hyprwhspr-rs/pull/133))


### Fixes
- allow null vad max speech in schema ([#135](https://github.com/better-slop/hyprwhspr-rs/pull/135))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).