### PR TITLE
fix: allow null vad max speech in schema

### DIFF
--- a/config/schema.json
+++ b/config/schema.json
@@ -548,7 +548,10 @@
           "default": false
         },
         "max_speech_s": {
-          "type": "number",
+          "type": [
+            "number",
+            "null"
+          ],
           "format": "float"
         },
         "min_silence_ms": {

--- a/src/config.rs
+++ b/src/config.rs
@@ -282,6 +282,7 @@ pub struct VadConfig {
         deserialize_with = "deserialize_vad_max_speech_s",
         skip_serializing_if = "is_f32_non_finite"
     )]
+    #[schemars(with = "Option<f32>")]
     pub max_speech_s: f32,
     pub speech_pad_ms: u32,
     pub samples_overlap: f32,

--- a/tests/config_serialization.rs
+++ b/tests/config_serialization.rs
@@ -12,6 +12,21 @@ fn checked_in_schema_is_current() {
 }
 
 #[test]
+fn schema_allows_null_vad_max_speech_s() {
+    let schema: serde_json::Value =
+        serde_json::from_str(include_str!("../config/schema.json")).expect("parse schema");
+    let max_speech_s = schema
+        .pointer("/$defs/VadConfig/properties/max_speech_s/type")
+        .expect("max_speech_s type schema");
+
+    assert_eq!(
+        max_speech_s,
+        &serde_json::json!(["number", "null"]),
+        "schema should match runtime deserialization, where max_speech_s: null means unlimited"
+    );
+}
+
+#[test]
 fn default_config_omits_infinite_max_speech_s() {
     let config = Config::default();
     let json = serde_json::to_string_pretty(&config).expect("serialize config");


### PR DESCRIPTION
Updates the generated config schema so `transcription.whisper_cpp.vad.max_speech_s` accepts `null`, matching runtime deserialization where null means unlimited. Adds a regression assertion to keep the schema aligned. Fixes https://github.com/better-slop/hyprwhspr-rs/pull/130#pullrequestreview-4357693542