### PR TITLE
feat(providers): support subscription providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ https://github.com/user-attachments/assets/bbbaa1c3-1a7e-4165-ad3d-27b7465e201a
   - Use `GEMINI_API_KEY` for provider `gemini`
   - Groq with whisper is cheap (~$0.10 USD/month) and fast as hell. [[Data Controls](https://console.groq.com/settings/data-controls)]
   - Comparatively, Gemini is very slow but offers better output formatting.
+- ChatGPT account via Codex auth (optional)
+  - Use `custom.openai-codex` with `~/.codex/auth.json`
 - Parakeet TDT (optional) - NVIDIA's local ASR model via ONNX
   - Run `./scripts/download-parakeet-tdt.sh` to download model files (~1.2GB)
   - Very fast, but not as accurate as whisper or Gemini
@@ -292,6 +294,28 @@ bind = ALT, SPACE, exec, hyprwhspr-rs record toggle
         "body": {},
         "prompt": "Transcribe as technical documentation with proper capitalization, acronyms, and technical terminology. Do not add punctuation.",
       },
+      "openai-codex": {
+        "kind": "openai_audio_transcriptions",
+        "label": "OpenAI Codex gpt-4o-mini-transcribe",
+        "base_url": {
+          "value": "https://chatgpt.com/backend-api",
+        },
+        "endpoint": "/transcribe",
+        "model": "gpt-4o-mini-transcribe",
+        "audio_format": "wav",
+        "subscription": {
+          "file": "~/.codex/auth.json", // Reads /tokens/access_token by default
+          // "json_pointer": "/tokens/access_token",
+          // "file_env": "HYPRWHSPR_REMOTE_WHISPER_AUTH_FILE",
+          // "env": "HYPRWHSPR_REMOTE_WHISPER_AUTH_TOKEN",
+        },
+        "headers": {
+          "originator": "Codex Desktop",
+          "User-Agent": "Codex Desktop/26.527.60818 (X11; Linux; x64)",
+        },
+        "body": {},
+        "prompt": "Transcribe as technical documentation with proper capitalization, acronyms, and technical terminology. Do not add punctuation.",
+      },
     },
   },
 }
@@ -313,6 +337,7 @@ Use <code>transcription.provider</code> in <code>~/.config/hyprwhspr-rs/config.j
 - gemini provider <strong>requires</strong>: <code>GEMINI_API_KEY</code>
 - whisper_cpp (whisper-cli) <strong>does not require an API key; the binary is discovered via <code>PATH</code> and managed locations under <code> $XDG_DATA_HOME </code> / <code> $HOME </code> </strong>
 - custom providers use <code>transcription.custom.&lt;name&gt;.api_key</code>. Secret resolution prefers <code>file_env</code>, then <code>file</code>, then <code>env</code>. Empty/missing keys are allowed for no-auth local servers.
+- custom providers may use <code>transcription.custom.&lt;name&gt;.subscription</code> for bearer tokens from subscription auth files. If configured, subscription auth is required and <code>api_key</code> is not used.
 
 #### Custom OpenAI-compatible providers
 
@@ -335,6 +360,10 @@ Set <code>transcription.provider</code> to <code>custom.&lt;name&gt;</code>, the
         "env": "HYPRWHSPR_REMOTE_WHISPER_API_KEY",
         "file": "/run/secrets/hyprwhspr-remote-key",
         "file_env": "HYPRWHSPR_REMOTE_WHISPER_API_KEY_FILE"
+      },
+      "subscription": {
+        "file": "~/.codex/auth.json",
+        "json_pointer": "/tokens/access_token"
       },
       "headers": {},
       "body": {},

--- a/config/schema.json
+++ b/config/schema.json
@@ -259,6 +259,15 @@
         "prompt": {
           "type": "string",
           "default": "Transcribe with proper capitalization, including sentence beginnings, proper nouns, titles, and standard English capitalization rules."
+        },
+        "subscription": {
+          "$ref": "#/$defs/SubscriptionAuthSource",
+          "default": {
+            "env": null,
+            "file": null,
+            "file_env": null,
+            "json_pointer": "/tokens/access_token"
+          }
         }
       }
     },
@@ -445,6 +454,43 @@
             "string",
             "null"
           ]
+        }
+      }
+    },
+    "SubscriptionAuthSource": {
+      "type": "object",
+      "properties": {
+        "env": {
+          "description": "Reads a bearer token directly from an environment variable.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "file": {
+          "description": "Reads a JSON auth file, such as ~/.codex/auth.json.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "file_env": {
+          "description": "Reads the JSON auth file path from an environment variable.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "json_pointer": {
+          "description": "JSON Pointer for the bearer token inside the auth file.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": "/tokens/access_token"
         }
       }
     },

--- a/src/config.rs
+++ b/src/config.rs
@@ -626,6 +626,122 @@ impl SecretSource {
     }
 }
 
+fn default_subscription_json_pointer() -> String {
+    "/tokens/access_token".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(default)]
+pub struct SubscriptionAuthSource {
+    /// Reads a bearer token directly from an environment variable.
+    pub env: Option<String>,
+    /// Reads a JSON auth file, such as ~/.codex/auth.json.
+    pub file: Option<String>,
+    /// Reads the JSON auth file path from an environment variable.
+    pub file_env: Option<String>,
+    /// JSON Pointer for the bearer token inside the auth file.
+    pub json_pointer: Option<String>,
+}
+
+impl Default for SubscriptionAuthSource {
+    fn default() -> Self {
+        Self {
+            env: None,
+            file: None,
+            file_env: None,
+            json_pointer: Some(default_subscription_json_pointer()),
+        }
+    }
+}
+
+impl SubscriptionAuthSource {
+    pub fn is_configured(&self) -> bool {
+        self.env
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|value| !value.is_empty())
+            || self
+                .file
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|value| !value.is_empty())
+            || self
+                .file_env
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|value| !value.is_empty())
+    }
+
+    pub fn resolve(&self, field_name: &str) -> Result<Option<String>> {
+        if let Some(env_name) = self
+            .env
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+        {
+            if let Ok(value) = env::var(env_name) {
+                let trimmed = value.trim();
+                if !trimmed.is_empty() {
+                    return Ok(Some(trimmed.to_string()));
+                }
+            }
+        }
+
+        if let Some(env_name) = self
+            .file_env
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+        {
+            if let Ok(path) = env::var(env_name) {
+                let trimmed = path.trim();
+                if !trimmed.is_empty() {
+                    return Self::read_json_token(
+                        trimmed,
+                        self.json_pointer.as_deref(),
+                        field_name,
+                    )
+                    .map(Some);
+                }
+            }
+        }
+
+        if let Some(path) = self
+            .file
+            .as_deref()
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+        {
+            return Self::read_json_token(path, self.json_pointer.as_deref(), field_name).map(Some);
+        }
+
+        Ok(None)
+    }
+
+    fn read_json_token(path: &str, json_pointer: Option<&str>, field_name: &str) -> Result<String> {
+        let expanded = expand_tilde(path);
+        let value = fs::read_to_string(&expanded)
+            .with_context(|| format!("Failed to read {field_name} auth file: {path}"))?;
+        let json: serde_json::Value = serde_json::from_str(&value)
+            .with_context(|| format!("Failed to parse {field_name} auth JSON: {path}"))?;
+
+        let pointer = json_pointer
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("/tokens/access_token");
+        let token = json
+            .pointer(pointer)
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                anyhow!("{field_name} token missing at JSON pointer {pointer}: {path}")
+            })?;
+
+        Ok(token.to_string())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(default)]
 pub struct CustomProviderConfig {
@@ -636,6 +752,7 @@ pub struct CustomProviderConfig {
     pub model: String,
     pub audio_format: String,
     pub api_key: SecretSource,
+    pub subscription: SubscriptionAuthSource,
     pub headers: HashMap<String, String>,
     pub body: HashMap<String, String>,
     pub prompt: String,
@@ -651,6 +768,7 @@ impl Default for CustomProviderConfig {
             model: String::new(),
             audio_format: "wav".to_string(),
             api_key: SecretSource::default(),
+            subscription: SubscriptionAuthSource::default(),
             headers: HashMap::new(),
             body: HashMap::new(),
             prompt: default_whisper_prompt(),

--- a/src/transcription/custom_openai.rs
+++ b/src/transcription/custom_openai.rs
@@ -40,7 +40,17 @@ impl CustomOpenAiTranscriber {
             let base_url = config.base_url.resolve("base_url")?;
             resolve_endpoint(Some(&base_url), &config.endpoint)?
         };
-        let api_key = config.api_key.resolve("api_key")?;
+        let api_key = if config.subscription.is_configured() {
+            let token = config
+                .subscription
+                .resolve("subscription")?
+                .ok_or_else(|| {
+                    anyhow::anyhow!("subscription auth source did not resolve a token")
+                })?;
+            Some(token)
+        } else {
+            config.api_key.resolve("api_key")?
+        };
 
         let client = Client::builder()
             .user_agent(format!("hyprwhspr-rs (custom:{name})"))

--- a/src/transcription/custom_openai.rs
+++ b/src/transcription/custom_openai.rs
@@ -1,9 +1,9 @@
-use crate::config::CustomProviderConfig;
-use crate::transcription::audio::{encode_to_flac, encode_to_wav, EncodedAudio};
+use crate::config::{CustomProviderConfig, SubscriptionAuthSource};
+use crate::transcription::audio::{EncodedAudio, encode_to_flac, encode_to_wav};
 use crate::transcription::postprocess::clean_transcription;
 use crate::transcription::{BackendMetrics, TranscriptionResult};
 use anyhow::{Context, Result};
-use reqwest::{header, multipart, Client, Url};
+use reqwest::{Client, Url, header, multipart};
 use serde::Deserialize;
 use std::cmp;
 use std::time::{Duration, Instant};
@@ -16,7 +16,7 @@ pub struct CustomOpenAiTranscriber {
     label: String,
     client: Client,
     endpoint: Url,
-    api_key: Option<String>,
+    auth: CustomAuth,
     model: String,
     audio_format: AudioFormat,
     headers: Vec<(String, String)>,
@@ -40,16 +40,20 @@ impl CustomOpenAiTranscriber {
             let base_url = config.base_url.resolve("base_url")?;
             resolve_endpoint(Some(&base_url), &config.endpoint)?
         };
-        let api_key = if config.subscription.is_configured() {
-            let token = config
+        let auth = if config.subscription.is_configured() {
+            config
                 .subscription
                 .resolve("subscription")?
                 .ok_or_else(|| {
                     anyhow::anyhow!("subscription auth source did not resolve a token")
                 })?;
-            Some(token)
+            CustomAuth::Subscription(config.subscription.clone())
         } else {
-            config.api_key.resolve("api_key")?
+            config
+                .api_key
+                .resolve("api_key")?
+                .map(CustomAuth::ApiKey)
+                .unwrap_or(CustomAuth::None)
         };
 
         let client = Client::builder()
@@ -68,7 +72,7 @@ impl CustomOpenAiTranscriber {
                 .unwrap_or_else(|| format!("Custom ({name})")),
             client,
             endpoint,
-            api_key,
+            auth,
             model: config.model.clone(),
             audio_format: AudioFormat::from_config(&config.audio_format)?,
             headers: config
@@ -210,9 +214,9 @@ impl CustomOpenAiTranscriber {
             request = request.header(key, value);
         }
 
-        if let Some(api_key) = &self.api_key {
-            if !has_authorization {
-                request = request.bearer_auth(api_key);
+        if !has_authorization {
+            if let Some(auth_token) = self.resolve_auth_token()? {
+                request = request.bearer_auth(auth_token);
             }
         }
 
@@ -253,6 +257,24 @@ impl CustomOpenAiTranscriber {
 
         Err(anyhow::anyhow!(message).context(format!("Custom request failed ({status})")))
     }
+
+    fn resolve_auth_token(&self) -> Result<Option<String>> {
+        match &self.auth {
+            CustomAuth::None => Ok(None),
+            CustomAuth::ApiKey(api_key) => Ok(Some(api_key.clone())),
+            CustomAuth::Subscription(source) => source
+                .resolve("subscription")?
+                .ok_or_else(|| anyhow::anyhow!("subscription auth source did not resolve a token"))
+                .map(Some),
+        }
+    }
+}
+
+#[derive(Clone)]
+enum CustomAuth {
+    None,
+    ApiKey(String),
+    Subscription(SubscriptionAuthSource),
 }
 
 #[derive(Clone, Copy)]
@@ -321,4 +343,160 @@ struct OpenAiErrorResponse {
 #[derive(Debug, Deserialize, Default)]
 struct OpenAiErrorDetail {
     message: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{SecretSource, ValueSource};
+    use bytes::Bytes;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn subscription_auth_is_resolved_for_each_request() {
+        let root = std::env::temp_dir().join(format!(
+            "hyprwhspr-rs-custom-openai-auth-refresh-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        let auth_path = root.join("auth.json");
+        write_auth_token(&auth_path, "first-token");
+
+        let (endpoint, mut auth_headers) = spawn_auth_capture_server().await;
+        let config = CustomProviderConfig {
+            base_url: ValueSource::default(),
+            endpoint,
+            model: "gpt-4o-mini-transcribe".to_string(),
+            audio_format: "wav".to_string(),
+            api_key: SecretSource::default(),
+            subscription: SubscriptionAuthSource {
+                file: Some(auth_path.to_string_lossy().into_owned()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let transcriber = CustomOpenAiTranscriber::new(
+            "auth_refresh",
+            &config,
+            Duration::from_secs(5),
+            0,
+            String::new(),
+        )
+        .expect("transcriber");
+
+        let audio = EncodedAudio {
+            data: Bytes::from_static(b"not-a-real-wav"),
+            content_type: "audio/wav",
+        };
+
+        transcriber.send_once(&audio).await.expect("first request");
+        assert_eq!(
+            auth_headers.recv().await.as_deref(),
+            Some("Bearer first-token")
+        );
+
+        write_auth_token(&auth_path, "second-token");
+        transcriber.send_once(&audio).await.expect("second request");
+        assert_eq!(
+            auth_headers.recv().await.as_deref(),
+            Some("Bearer second-token")
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    fn write_auth_token(path: &std::path::Path, token: &str) {
+        std::fs::write(
+            path,
+            format!(
+                r#"{{
+                    "tokens": {{
+                        "access_token": "{token}"
+                    }}
+                }}"#
+            ),
+        )
+        .expect("write auth token");
+    }
+
+    async fn spawn_auth_capture_server() -> (String, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let endpoint = format!(
+            "http://{}/v1/audio/transcriptions",
+            listener.local_addr().expect("local addr")
+        );
+        let (tx, rx) = mpsc::channel(2);
+
+        tokio::spawn(async move {
+            for _ in 0..2 {
+                let (stream, _) = listener.accept().await.expect("accept request");
+                let tx = tx.clone();
+                tokio::spawn(async move {
+                    let auth = read_authorization_header(stream)
+                        .await
+                        .expect("read request");
+                    tx.send(auth).await.expect("send auth header");
+                });
+            }
+        });
+
+        (endpoint, rx)
+    }
+
+    async fn read_authorization_header(mut stream: TcpStream) -> Result<String> {
+        let mut buffer = Vec::new();
+        let mut chunk = [0; 1024];
+        let header_end = loop {
+            let read = stream.read(&mut chunk).await?;
+            if read == 0 {
+                anyhow::bail!("request closed before headers");
+            }
+            buffer.extend_from_slice(&chunk[..read]);
+            if let Some(position) = find_header_end(&buffer) {
+                break position;
+            }
+        };
+
+        let headers = String::from_utf8_lossy(&buffer[..header_end]).into_owned();
+        let content_length = headers
+            .lines()
+            .filter_map(|line| line.split_once(':'))
+            .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+            .and_then(|(_, value)| value.trim().parse::<usize>().ok())
+            .unwrap_or(0);
+        let body_start = header_end + 4;
+        while buffer.len().saturating_sub(body_start) < content_length {
+            let read = stream.read(&mut chunk).await?;
+            if read == 0 {
+                break;
+            }
+            buffer.extend_from_slice(&chunk[..read]);
+        }
+
+        let auth = headers
+            .lines()
+            .filter_map(|line| line.split_once(':'))
+            .find(|(name, _)| name.eq_ignore_ascii_case("authorization"))
+            .map(|(_, value)| value.trim().to_string())
+            .context("missing authorization header")?;
+
+        let body = br#"{"text":""}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+            body.len()
+        );
+        stream.write_all(response.as_bytes()).await?;
+        stream.write_all(body).await?;
+        stream.shutdown().await?;
+
+        Ok(auth)
+    }
+
+    fn find_header_end(buffer: &[u8]) -> Option<usize> {
+        buffer.windows(4).position(|window| window == b"\r\n\r\n")
+    }
 }

--- a/tests/custom_provider_config.rs
+++ b/tests/custom_provider_config.rs
@@ -1,6 +1,6 @@
 use hyprwhspr_rs::config::{
-    Config, CustomProviderConfig, CustomProviderKind, SecretSource, TranscriptionProvider,
-    ValueSource,
+    Config, CustomProviderConfig, CustomProviderKind, SecretSource, SubscriptionAuthSource,
+    TranscriptionProvider, ValueSource,
 };
 use hyprwhspr_rs::transcription::CustomOpenAiTranscriber;
 use std::time::Duration;
@@ -24,6 +24,9 @@ fn custom_provider_config_deserializes_requested_shape() {
                         "env": "HYPRWHSPR_REMOTE_WHISPER_API_KEY",
                         "file": "/run/secrets/hyprwhspr-remote-key",
                         "file_env": "HYPRWHSPR_REMOTE_WHISPER_API_KEY_FILE"
+                    },
+                    "subscription": {
+                        "file": "~/.codex/auth.json"
                     },
                     "headers": {
                         "x-provider": "whisper.cpp"
@@ -71,6 +74,13 @@ fn custom_provider_config_deserializes_requested_shape() {
         }
     );
     assert_eq!(
+        custom.subscription,
+        SubscriptionAuthSource {
+            file: Some("~/.codex/auth.json".to_string()),
+            ..Default::default()
+        }
+    );
+    assert_eq!(
         custom.headers.get("x-provider").map(String::as_str),
         Some("whisper.cpp")
     );
@@ -102,6 +112,7 @@ fn custom_provider_round_trips() {
                 file: None,
                 file_env: Some("HYPRWHSPR_REMOTE_WHISPER_API_KEY_FILE".to_string()),
             },
+            subscription: SubscriptionAuthSource::default(),
             headers: [("x-provider".to_string(), "whisper.cpp".to_string())].into(),
             body: [("response_format".to_string(), "json".to_string())].into(),
             prompt: "Transcribe technical notes.".to_string(),
@@ -124,11 +135,18 @@ fn custom_provider_allows_absolute_endpoint_without_base_url() {
         model: "whisper-large-v3".to_string(),
         audio_format: "wav".to_string(),
         api_key: SecretSource::default(),
+        subscription: SubscriptionAuthSource::default(),
         headers: Default::default(),
         body: Default::default(),
         prompt: String::new(),
     };
 
-    CustomOpenAiTranscriber::new("fixed_url", &config, Duration::from_secs(5), 0, String::new())
-        .expect("absolute endpoint should not require base_url");
+    CustomOpenAiTranscriber::new(
+        "fixed_url",
+        &config,
+        Duration::from_secs(5),
+        0,
+        String::new(),
+    )
+    .expect("absolute endpoint should not require base_url");
 }

--- a/tests/custom_provider_sources.rs
+++ b/tests/custom_provider_sources.rs
@@ -1,4 +1,4 @@
-use hyprwhspr_rs::config::{SecretSource, ValueSource};
+use hyprwhspr_rs::config::{SecretSource, SubscriptionAuthSource, ValueSource};
 
 #[test]
 fn value_source_prefers_non_empty_env_over_config_value() {
@@ -75,5 +75,66 @@ fn secret_source_prefers_file_env_then_file_then_env() {
     );
 
     std::env::remove_var("HYPRWHSPR_TEST_API_KEY");
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn subscription_auth_source_reads_codex_auth_json_access_token() {
+    let root = std::env::temp_dir().join(format!(
+        "hyprwhspr-rs-subscription-source-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&root).expect("create temp dir");
+    let auth_path = root.join("auth.json");
+    std::fs::write(
+        &auth_path,
+        r#"{
+            "auth_mode": "chatgpt",
+            "tokens": {
+                "access_token": "from-codex-auth",
+                "refresh_token": "refresh-token"
+            }
+        }"#,
+    )
+    .expect("write auth json");
+
+    let source = SubscriptionAuthSource {
+        file: Some(auth_path.to_string_lossy().into_owned()),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        source
+            .resolve("subscription")
+            .expect("resolved subscription token"),
+        Some("from-codex-auth".to_string())
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn subscription_auth_source_uses_custom_json_pointer() {
+    let root = std::env::temp_dir().join(format!(
+        "hyprwhspr-rs-subscription-source-pointer-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&root).expect("create temp dir");
+    let auth_path = root.join("auth.json");
+    std::fs::write(&auth_path, r#"{"nested":{"token":"from-pointer"}}"#).expect("write auth json");
+
+    let source = SubscriptionAuthSource {
+        file: Some(auth_path.to_string_lossy().into_owned()),
+        json_pointer: Some("/nested/token".to_string()),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        source
+            .resolve("subscription")
+            .expect("resolved subscription token"),
+        Some("from-pointer".to_string())
+    );
+
     let _ = std::fs::remove_dir_all(&root);
 }

--- a/tests/custom_whisper_cpp_server.rs
+++ b/tests/custom_whisper_cpp_server.rs
@@ -10,7 +10,8 @@
 //! ```
 
 use hyprwhspr_rs::config::{
-    Config, CustomProviderConfig, CustomProviderKind, TranscriptionProvider, ValueSource,
+    Config, CustomProviderConfig, CustomProviderKind, SubscriptionAuthSource,
+    TranscriptionProvider, ValueSource,
 };
 use hyprwhspr_rs::transcription::CustomOpenAiTranscriber;
 use std::process::{Child, Command, Stdio};
@@ -44,6 +45,7 @@ async fn custom_provider_transcribes_against_whisper_cpp_server() {
             model: "whisper-large-v3".to_string(),
             audio_format: "wav".to_string(),
             api_key: Default::default(),
+            subscription: SubscriptionAuthSource::default(),
             headers: Default::default(),
             body: Default::default(),
             prompt: String::new(),


### PR DESCRIPTION
supports gpt-4o-mini-transcribe via custom provider shape `custom.openai-codex`. Will likely work with copilot or others, but hasn't been tested.