### PR TITLE
fix(shortcuts): input loss/rescan/change bugginess

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -279,7 +279,7 @@ impl HyprwhsprApp {
         })
     }
 
-    pub async fn run(mut self) -> Result<()> {
+    pub async fn run(&mut self) -> Result<()> {
         info!("🚀 hyprwhspr running!");
 
         let mut shortcut_rx = self

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -129,7 +129,7 @@ impl GlobalShortcuts {
                     _ => {
                         self.handle_input_device_event(event);
                         pressed_keys.clear();
-                        combination_active = false;
+                        release_active_hold_shortcut(&tx, self.kind, &mut combination_active);
                     }
                 }
             }
@@ -260,14 +260,14 @@ impl GlobalShortcuts {
                     info!("Removed {} keyboard device(s)", removed);
                 }
                 pressed_keys.clear();
-                combination_active = false;
+                release_active_hold_shortcut(&tx, self.kind, &mut combination_active);
             }
 
             if fallback_rescan_enabled && last_fallback_rescan.elapsed() >= fallback_rescan_interval
             {
                 last_fallback_rescan = Instant::now();
                 pressed_keys.clear();
-                combination_active = false;
+                release_active_hold_shortcut(&tx, self.kind, &mut combination_active);
                 if let Err(err) = self.refresh_devices() {
                     error!("Failed to refresh keyboard devices: {}", err);
                 }
@@ -556,6 +556,33 @@ impl GlobalShortcuts {
     }
 }
 
+fn release_active_hold_shortcut(
+    tx: &mpsc::Sender<ShortcutEvent>,
+    kind: ShortcutKind,
+    combination_active: &mut bool,
+) {
+    if !*combination_active {
+        return;
+    }
+
+    *combination_active = false;
+
+    if !matches!(kind, ShortcutKind::Hold) {
+        return;
+    }
+
+    if let Err(err) = tx.try_send(ShortcutEvent {
+        triggered_at: Instant::now(),
+        kind,
+        phase: ShortcutPhase::End,
+    }) {
+        warn!(
+            "Failed to send shortcut release event after input device change: {}",
+            err
+        );
+    }
+}
+
 fn is_device_disconnect_error(err: &io::Error) -> bool {
     match err.raw_os_error() {
         Some(code) if code == libc::ENODEV || code == libc::EBADF || code == libc::ENXIO => true,
@@ -623,5 +650,29 @@ mod tests {
         assert!(is_input_event_node(Path::new("/dev/input/event10")));
         assert!(!is_input_event_node(Path::new("/dev/input/mouse0")));
         assert!(!is_input_event_node(Path::new("/tmp/event0")));
+    }
+
+    #[test]
+    fn active_hold_disconnect_emits_release() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let mut combination_active = true;
+
+        release_active_hold_shortcut(&tx, ShortcutKind::Hold, &mut combination_active);
+
+        let event = rx.try_recv().expect("hold release event");
+        assert!(!combination_active);
+        assert_eq!(event.kind, ShortcutKind::Hold);
+        assert_eq!(event.phase, ShortcutPhase::End);
+    }
+
+    #[test]
+    fn active_press_disconnect_does_not_emit_release() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let mut combination_active = true;
+
+        release_active_hold_shortcut(&tx, ShortcutKind::Press, &mut combination_active);
+
+        assert!(!combination_active);
+        assert!(rx.try_recv().is_err());
     }
 }

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -270,10 +270,19 @@ impl GlobalShortcuts {
             if fallback_rescan_enabled && last_fallback_rescan.elapsed() >= fallback_rescan_interval
             {
                 last_fallback_rescan = Instant::now();
-                pressed_keys.clear();
-                release_hold_shortcut_on_input_change(&tx, self.kind, &mut combination_active);
-                if let Err(err) = self.refresh_devices() {
-                    error!("Failed to refresh keyboard devices: {}", err);
+                match self.refresh_devices() {
+                    Ok(true) => {
+                        pressed_keys.clear();
+                        release_hold_shortcut_on_input_change(
+                            &tx,
+                            self.kind,
+                            &mut combination_active,
+                        );
+                    }
+                    Ok(false) => {}
+                    Err(err) => {
+                        error!("Failed to refresh keyboard devices: {}", err);
+                    }
                 }
             }
 
@@ -424,10 +433,18 @@ impl GlobalShortcuts {
         Ok(keyboards)
     }
 
-    fn refresh_devices(&mut self) -> Result<()> {
+    fn refresh_devices(&mut self) -> Result<bool> {
+        let previous_paths: HashSet<PathBuf> = self
+            .devices
+            .iter()
+            .map(|device| device.path.clone())
+            .collect();
         let devices = Self::find_keyboard_devices(false)?;
         let previous = self.devices.len();
         let updated = devices.len();
+        let updated_paths: HashSet<PathBuf> =
+            devices.iter().map(|device| device.path.clone()).collect();
+        let changed = previous_paths != updated_paths;
 
         if updated == 0 && previous != 0 {
             warn!("No keyboard devices found!");
@@ -445,7 +462,7 @@ impl GlobalShortcuts {
 
         self.devices = devices;
 
-        Ok(())
+        Ok(changed)
     }
 
     fn is_keyboard_device(device: &Device) -> bool {

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -129,7 +129,11 @@ impl GlobalShortcuts {
                     _ => {
                         self.handle_input_device_event(event);
                         pressed_keys.clear();
-                        release_active_hold_shortcut(&tx, self.kind, &mut combination_active);
+                        release_hold_shortcut_on_input_change(
+                            &tx,
+                            self.kind,
+                            &mut combination_active,
+                        );
                     }
                 }
             }
@@ -260,14 +264,14 @@ impl GlobalShortcuts {
                     info!("Removed {} keyboard device(s)", removed);
                 }
                 pressed_keys.clear();
-                release_active_hold_shortcut(&tx, self.kind, &mut combination_active);
+                release_hold_shortcut_on_input_change(&tx, self.kind, &mut combination_active);
             }
 
             if fallback_rescan_enabled && last_fallback_rescan.elapsed() >= fallback_rescan_interval
             {
                 last_fallback_rescan = Instant::now();
                 pressed_keys.clear();
-                release_active_hold_shortcut(&tx, self.kind, &mut combination_active);
+                release_hold_shortcut_on_input_change(&tx, self.kind, &mut combination_active);
                 if let Err(err) = self.refresh_devices() {
                     error!("Failed to refresh keyboard devices: {}", err);
                 }
@@ -556,15 +560,11 @@ impl GlobalShortcuts {
     }
 }
 
-fn release_active_hold_shortcut(
+fn release_hold_shortcut_on_input_change(
     tx: &mpsc::Sender<ShortcutEvent>,
     kind: ShortcutKind,
     combination_active: &mut bool,
 ) {
-    if !*combination_active {
-        return;
-    }
-
     *combination_active = false;
 
     if !matches!(kind, ShortcutKind::Hold) {
@@ -577,7 +577,7 @@ fn release_active_hold_shortcut(
         phase: ShortcutPhase::End,
     }) {
         warn!(
-            "Failed to send shortcut release event after input device change: {}",
+            "Failed to send hold shortcut release event after input device change: {}",
             err
         );
     }
@@ -657,7 +657,20 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(1);
         let mut combination_active = true;
 
-        release_active_hold_shortcut(&tx, ShortcutKind::Hold, &mut combination_active);
+        release_hold_shortcut_on_input_change(&tx, ShortcutKind::Hold, &mut combination_active);
+
+        let event = rx.try_recv().expect("hold release event");
+        assert!(!combination_active);
+        assert_eq!(event.kind, ShortcutKind::Hold);
+        assert_eq!(event.phase, ShortcutPhase::End);
+    }
+
+    #[test]
+    fn inactive_hold_disconnect_still_emits_release() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let mut combination_active = false;
+
+        release_hold_shortcut_on_input_change(&tx, ShortcutKind::Hold, &mut combination_active);
 
         let event = rx.try_recv().expect("hold release event");
         assert!(!combination_active);
@@ -670,7 +683,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(1);
         let mut combination_active = true;
 
-        release_active_hold_shortcut(&tx, ShortcutKind::Press, &mut combination_active);
+        release_hold_shortcut_on_input_change(&tx, ShortcutKind::Press, &mut combination_active);
 
         assert!(!combination_active);
         assert!(rx.try_recv().is_err());

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ async fn main() -> Result<()> {
     info!("   Audio feedback: {}", config.audio_feedback);
 
     // Initialize application
-    let app = HyprwhsprApp::new(config_manager)?;
+    let mut app = HyprwhsprApp::new(config_manager)?;
 
     // Set up signal handling
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
@@ -127,6 +127,7 @@ async fn main() -> Result<()> {
 
     // Cleanup
     info!("🛑 Shutting down hyprwhspr-rs...");
+    app.cleanup().await?;
     info!("✅ Shutdown complete");
 
     Ok(())


### PR DESCRIPTION
When a keyboard device is removed/changed/rescanned while a hold combo is active, synthesize ShortcutPhase::End instead of silently clearing combination_active.

Closes #138 