### PR TITLE
chore: release v0.3.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.3.31] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.30...v0.3.31) - 2026-06-21
+
+### Features
+- improve perf and tooling around resource analysis ([#145](https://github.com/better-slop/hyprwhspr-rs/pull/145))
+- *(text)* normalize transcripts with ITN ([#144](https://github.com/better-slop/hyprwhspr-rs/pull/144))
+- improve shortcut/input handling ([#143](https://github.com/better-slop/hyprwhspr-rs/pull/143))
+
+
+### Fixes
+- *(shortcuts)* input loss/rescan/change bugginess ([#139](https://github.com/better-slop/hyprwhspr-rs/pull/139))
+
+
+### Other
+- update readme
+
 ## [0.3.30] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.29...v0.3.30) - 2026-06-08
 
 ### Chores

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "hyprwhspr-rs"
-version = "0.3.30"
+version = "0.3.31"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4729,11 +4729,3 @@ checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
  "zune-core",
 ]
-
-[[patch.unused]]
-name = "gtk4-layer-shell"
-version = "0.7.1"
-
-[[patch.unused]]
-name = "gtk4-layer-shell-sys"
-version = "0.5.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyprwhspr-rs"
-version = "0.3.30"
+version = "0.3.31"
 edition = "2021"
 authors = ["hyprwhspr-rs contributors"]
 description = "Native speech-to-text voice dictation for Hyprland (Rust implementation)"


### PR DESCRIPTION



## 🤖 New release

* `hyprwhspr-rs`: 0.3.30 -> 0.3.31 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.31] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.30...v0.3.31) - 2026-06-21

### Features
- improve perf and tooling around resource analysis ([#145](https://github.com/better-slop/hyprwhspr-rs/pull/145))
- *(text)* normalize transcripts with ITN ([#144](https://github.com/better-slop/hyprwhspr-rs/pull/144))
- improve shortcut/input handling ([#143](https://github.com/better-slop/hyprwhspr-rs/pull/143))


### Fixes
- *(shortcuts)* input loss/rescan/change bugginess ([#139](https://github.com/better-slop/hyprwhspr-rs/pull/139))


### Other
- update readme
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).