### PR TITLE
feat: improve shortcut/input handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,6 +996,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -1242,6 +1254,7 @@ dependencies = [
  "earshot",
  "enigo",
  "evdev",
+ "futures-util",
  "jsonc-parser",
  "libc",
  "owo-colors",
@@ -1255,6 +1268,7 @@ dependencies = [
  "similar",
  "time",
  "tokio",
+ "tokio-udev",
  "tracing",
  "tracing-subscriber",
  "udev",
@@ -3356,6 +3370,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-udev"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d239a184f334141ead9fce462203705d199d053a63d00e25c8caf4e717149233"
+dependencies = [
+ "futures-core",
+ "tokio",
+ "udev",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4678,3 +4703,11 @@ checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
  "zune-core",
 ]
+
+[[patch.unused]]
+name = "gtk4-layer-shell"
+version = "0.7.1"
+
+[[patch.unused]]
+name = "gtk4-layer-shell-sys"
+version = "0.5.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://github.com/better-slop/hyprwhspr-rs#readme"
 [dependencies]
 # Async runtime
 tokio = { version = "1", features = ["io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
+futures-util = "0.3"
 
 # Config & serialization
 serde = { version = "1", features = ["derive"] }
@@ -35,6 +36,7 @@ earshot = "0.1"
 # Input
 evdev = "0.12"
 udev = "0.9.3"
+tokio-udev = "0.10"
 arboard = { version = "3", features = ["wayland-data-control"] }
 enigo = { version = "0.2", default-features = false, features = ["wayland"] }
 libc = "0.2"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,9 +1,5 @@
 use anyhow::{Context, Result};
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
-use std::thread::{self, JoinHandle};
+use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::{mpsc, Mutex};
 use tracing::{debug, error, info, warn};
@@ -14,17 +10,10 @@ use crate::audio::{
 use crate::benchmark::BenchmarkRecorder;
 use crate::config::{Config, ConfigManager, ShortcutsConfig, TranscriptionProvider};
 use crate::control::{ControlRequest, ControlServer, RecordCommand, RecorderState};
-use crate::input::{GlobalShortcuts, ShortcutEvent, ShortcutKind, ShortcutPhase, TextInjector};
+use crate::input::{InputManagerHandle, ShortcutEvent, ShortcutKind, ShortcutPhase, TextInjector};
 use crate::status::{StatusWriter, WaybarState};
 use crate::transcription::{TranscriptionBackend, TranscriptionResult};
 use crate::whisper::WhisperVadOptions;
-
-struct ShortcutListener {
-    stop_flag: Arc<AtomicBool>,
-    handle: Option<JoinHandle<()>>,
-    shortcut: String,
-    kind: ShortcutKind,
-}
 
 fn resample_audio(samples: &[f32], src_rate: u32, dst_rate: u32) -> Vec<f32> {
     if samples.is_empty() || src_rate == 0 || dst_rate == 0 {
@@ -59,67 +48,6 @@ fn resample_audio(samples: &[f32], src_rate: u32, dst_rate: u32) -> Vec<f32> {
     }
 
     output
-}
-
-impl ShortcutListener {
-    fn spawn(
-        shortcut: String,
-        kind: ShortcutKind,
-        tx: mpsc::Sender<ShortcutEvent>,
-    ) -> Result<Self> {
-        let stop_flag = Arc::new(AtomicBool::new(false));
-        let runner_flag = Arc::clone(&stop_flag);
-        let runner_tx = tx.clone();
-        let shortcut_name = shortcut.clone();
-
-        let handle = thread::spawn(move || match GlobalShortcuts::new(&shortcut, kind) {
-            Ok(shortcuts) => {
-                if let Err(e) = shortcuts.run(runner_tx, runner_flag) {
-                    error!("Global shortcuts error: {}", e);
-                }
-            }
-            Err(e) => {
-                error!("Failed to initialize global shortcuts: {}", e);
-            }
-        });
-
-        Ok(Self {
-            stop_flag,
-            handle: Some(handle),
-            shortcut: shortcut_name,
-            kind,
-        })
-    }
-
-    fn restart(
-        &mut self,
-        shortcut: String,
-        kind: ShortcutKind,
-        tx: mpsc::Sender<ShortcutEvent>,
-    ) -> Result<()> {
-        self.stop();
-        *self = Self::spawn(shortcut, kind, tx)?;
-        Ok(())
-    }
-
-    fn stop(&mut self) {
-        self.stop_flag.store(true, Ordering::Relaxed);
-        if let Some(handle) = self.handle.take() {
-            if let Err(err) = handle.join() {
-                error!("Shortcut listener thread panicked: {:?}", err);
-            }
-        }
-    }
-
-    fn matches(&self, shortcut: &str, kind: ShortcutKind) -> bool {
-        self.shortcut == shortcut && self.kind == kind
-    }
-}
-
-impl Drop for ShortcutListener {
-    fn drop(&mut self) {
-        self.stop();
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -181,8 +109,7 @@ pub struct HyprwhsprApp {
     shortcut_rx: Option<mpsc::Receiver<ShortcutEvent>>,
     control_tx: mpsc::Sender<ControlRequest>,
     control_rx: Option<mpsc::Receiver<ControlRequest>>,
-    press_listener: Option<ShortcutListener>,
-    hold_listener: Option<ShortcutListener>,
+    input_manager: Option<InputManagerHandle>,
     current_config: Config,
     recording_session: Option<RecordingSession>,
     recording_trigger: Option<RecordingTrigger>,
@@ -269,8 +196,7 @@ impl HyprwhsprApp {
             shortcut_rx: Some(shortcut_rx),
             control_tx,
             control_rx: Some(control_rx),
-            press_listener: None,
-            hold_listener: None,
+            input_manager: None,
             current_config: config,
             recording_session: None,
             recording_trigger: None,
@@ -291,7 +217,7 @@ impl HyprwhsprApp {
             .take()
             .expect("control receiver already consumed");
         let _control_server = ControlServer::spawn(self.control_tx.clone())?;
-        self.ensure_shortcut_listeners(self.current_config.shortcuts.clone())?;
+        self.ensure_input_manager(self.current_config.shortcuts.clone())?;
         self.log_shortcut_configuration(&self.current_config.shortcuts);
 
         let mut config_rx = self.config_manager.subscribe();
@@ -340,39 +266,22 @@ impl HyprwhsprApp {
         Ok(())
     }
 
-    fn ensure_shortcut_listeners(&mut self, shortcuts: ShortcutsConfig) -> Result<()> {
-        self.ensure_listener(ShortcutKind::Press, shortcuts.press.clone())?;
-        self.ensure_listener(ShortcutKind::Hold, shortcuts.hold.clone())
+    fn ensure_input_manager(&mut self, shortcuts: ShortcutsConfig) -> Result<()> {
+        if let Some(manager) = &self.input_manager {
+            manager.update_shortcuts(shortcuts)?;
+        } else {
+            self.input_manager = Some(InputManagerHandle::spawn(
+                shortcuts,
+                self.shortcut_tx.clone(),
+            )?);
+        }
+        Ok(())
     }
 
-    fn ensure_listener(&mut self, kind: ShortcutKind, shortcut: Option<String>) -> Result<()> {
-        let slot = match kind {
-            ShortcutKind::Press => &mut self.press_listener,
-            ShortcutKind::Hold => &mut self.hold_listener,
-        };
-
-        match shortcut {
-            Some(ref target) => {
-                if let Some(listener) = slot {
-                    if listener.matches(target, kind) {
-                        return Ok(());
-                    }
-                    listener.restart(target.clone(), kind, self.shortcut_tx.clone())?;
-                } else {
-                    let listener =
-                        ShortcutListener::spawn(target.clone(), kind, self.shortcut_tx.clone())?;
-                    *slot = Some(listener);
-                }
-            }
-            None => {
-                if let Some(listener) = slot.as_mut() {
-                    listener.stop();
-                }
-                *slot = None;
-            }
+    fn set_input_app_busy(&self, app_busy: bool) {
+        if let Some(manager) = &self.input_manager {
+            manager.set_app_busy(app_busy);
         }
-
-        Ok(())
     }
 
     fn apply_config_update(&mut self, new_config: Config) -> Result<()> {
@@ -429,12 +338,11 @@ impl HyprwhsprApp {
             self.transcriber = backend;
         }
 
-        let shortcuts_changed = new_config.shortcuts != self.current_config.shortcuts
-            || self.press_listener.is_none()
-            || (new_config.hold_shortcut().is_some() && self.hold_listener.is_none());
+        let shortcuts_changed =
+            new_config.shortcuts != self.current_config.shortcuts || self.input_manager.is_none();
 
         if shortcuts_changed {
-            self.ensure_shortcut_listeners(new_config.shortcuts.clone())?;
+            self.ensure_input_manager(new_config.shortcuts.clone())?;
             self.log_shortcut_configuration(&new_config.shortcuts);
         }
 
@@ -622,6 +530,7 @@ impl HyprwhsprApp {
 
         self.recording_session = Some(session);
         self.recording_trigger = Some(trigger);
+        self.set_input_app_busy(true);
 
         let recording_started_at = Instant::now();
         self.benchmark = Some(BenchmarkRecorder::new(
@@ -671,6 +580,7 @@ impl HyprwhsprApp {
             }
             self.benchmark = None;
             self.is_processing = false;
+            self.set_input_app_busy(false);
             // Return to inactive state after processing
             self.status_writer
                 .set_state(WaybarState::Inactive, "Ready")
@@ -678,6 +588,7 @@ impl HyprwhsprApp {
         } else {
             warn!("No audio data captured");
             self.benchmark = None;
+            self.set_input_app_busy(false);
             self.status_writer
                 .set_state(WaybarState::Inactive, "Ready")
                 .unwrap_or_else(|e| tracing::warn!("Failed to set inactive status: {}", e));
@@ -879,15 +790,10 @@ impl HyprwhsprApp {
         }
         self.status_writer.cleanup()?;
 
-        if let Some(listener) = &mut self.press_listener {
-            listener.stop();
+        if let Some(manager) = &mut self.input_manager {
+            manager.stop();
         }
-        self.press_listener = None;
-
-        if let Some(listener) = &mut self.hold_listener {
-            listener.stop();
-        }
-        self.hold_listener = None;
+        self.input_manager = None;
         self.recording_trigger = None;
 
         info!("✅ Cleanup completed");

--- a/src/input/manager.rs
+++ b/src/input/manager.rs
@@ -245,9 +245,16 @@ impl InputManagerRuntime {
                     }
                 }
                 _ = evdev_tick.tick() => {
-                    let key_events = self.registry.poll_key_events(MAX_KEY_EVENTS_PER_TICK)?;
-                    if key_events > 0 {
-                        self.stats.key_events_seen += key_events as u64;
+                    let outcome = self.registry.poll_key_events(MAX_KEY_EVENTS_PER_TICK)?;
+                    if outcome.key_events > 0 {
+                        self.stats.key_events_seen += outcome.key_events as u64;
+                    }
+                    if outcome.devices_changed {
+                        if let Some(event) = self.shortcuts.on_device_set_changed() {
+                            self.emit_shortcut(event);
+                        }
+                    }
+                    if outcome.key_events > 0 || outcome.devices_changed {
                         let now = Instant::now();
                         for event in self.shortcuts.apply_key_state(self.registry.pressed_keys(), now) {
                             self.emit_shortcut(event);

--- a/src/input/manager.rs
+++ b/src/input/manager.rs
@@ -1,0 +1,403 @@
+use anyhow::{Context, Result};
+use futures_util::StreamExt;
+use std::future;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+use tokio::sync::{mpsc, oneshot};
+use tokio::time;
+use tokio_udev::{AsyncMonitorSocket, EventType, MonitorBuilder};
+use tracing::{debug, error, info, warn};
+
+use crate::config::ShortcutsConfig;
+use crate::input::registry::{is_input_event_node, KeyboardRegistry};
+use crate::input::shortcuts::{ShortcutController, ShortcutEvent, ShortcutPhase, ShortcutSummary};
+
+const EVDEV_TICK: Duration = Duration::from_millis(10);
+const UDEV_DEBOUNCE: Duration = Duration::from_millis(150);
+const UDEV_MAX_WAIT: Duration = Duration::from_secs(1);
+const MAX_KEY_EVENTS_PER_TICK: usize = 256;
+
+#[derive(Debug, Clone, Default)]
+pub struct InputStats {
+    pub udev_events_seen: u64,
+    pub udev_events_coalesced: u64,
+    pub device_refreshes: u64,
+    pub key_events_seen: u64,
+    pub shortcut_events_emitted: u64,
+    pub loop_busy_ticks: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct InputSnapshot {
+    pub device_count: usize,
+    pub devices: Vec<PathBuf>,
+    pub shortcuts: Vec<ShortcutSummary>,
+    pub app_busy: bool,
+    pub stats: InputStats,
+}
+
+pub struct InputManagerHandle {
+    command_tx: mpsc::UnboundedSender<InputManagerCommand>,
+    handle: Option<JoinHandle<()>>,
+}
+
+enum InputManagerCommand {
+    UpdateShortcuts(ShortcutsConfig),
+    SetAppBusy(bool),
+    Snapshot(oneshot::Sender<InputSnapshot>),
+    Shutdown,
+}
+
+struct InputManagerRuntime {
+    command_rx: mpsc::UnboundedReceiver<InputManagerCommand>,
+    event_tx: mpsc::Sender<ShortcutEvent>,
+    registry: KeyboardRegistry,
+    shortcuts: ShortcutController,
+    coalescer: UdevCoalescer,
+    stats: InputStats,
+    app_busy: bool,
+    last_busy_log: Instant,
+}
+
+#[derive(Default)]
+struct UdevCoalescer {
+    dirty_since: Option<Instant>,
+    last_event_at: Option<Instant>,
+    fallback_rescan: bool,
+    last_fallback_rescan: Option<Instant>,
+}
+
+impl InputManagerHandle {
+    pub fn spawn(
+        shortcuts: ShortcutsConfig,
+        event_tx: mpsc::Sender<ShortcutEvent>,
+    ) -> Result<Self> {
+        ShortcutController::new(shortcuts.clone())?;
+        let (command_tx, command_rx) = mpsc::unbounded_channel();
+        let (init_tx, init_rx) = std::sync::mpsc::sync_channel(1);
+
+        let handle = thread::spawn(move || {
+            let result = run_input_thread(shortcuts, event_tx, command_rx);
+            if let Err(err) = result {
+                error!("Input manager stopped: {:#}", err);
+            }
+            let _ = init_tx.send(());
+        });
+
+        // Surface fast thread-start failures without forcing the app to block on the manager.
+        if let Ok(()) = init_rx.recv_timeout(Duration::from_millis(1)) {
+            warn!("Input manager exited during startup");
+        }
+
+        Ok(Self {
+            command_tx,
+            handle: Some(handle),
+        })
+    }
+
+    pub fn update_shortcuts(&self, shortcuts: ShortcutsConfig) -> Result<()> {
+        ShortcutController::new(shortcuts.clone())?;
+        self.command_tx
+            .send(InputManagerCommand::UpdateShortcuts(shortcuts))
+            .context("input manager is not running")
+    }
+
+    pub fn set_app_busy(&self, app_busy: bool) {
+        if let Err(err) = self
+            .command_tx
+            .send(InputManagerCommand::SetAppBusy(app_busy))
+        {
+            debug!("Failed to update input manager app-busy state: {}", err);
+        }
+    }
+
+    pub async fn snapshot(&self) -> Result<InputSnapshot> {
+        let (tx, rx) = oneshot::channel();
+        self.command_tx
+            .send(InputManagerCommand::Snapshot(tx))
+            .context("input manager is not running")?;
+        rx.await.context("input manager dropped snapshot reply")
+    }
+
+    pub fn stop(&mut self) {
+        let _ = self.command_tx.send(InputManagerCommand::Shutdown);
+        if let Some(handle) = self.handle.take() {
+            if let Err(err) = handle.join() {
+                error!("Input manager thread panicked: {:?}", err);
+            }
+        }
+    }
+}
+
+impl Drop for InputManagerHandle {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn run_input_thread(
+    shortcuts: ShortcutsConfig,
+    event_tx: mpsc::Sender<ShortcutEvent>,
+    command_rx: mpsc::UnboundedReceiver<InputManagerCommand>,
+) -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .context("failed to build input manager runtime")?;
+
+    runtime.block_on(async move {
+        let manager = InputManagerRuntime::new(shortcuts, event_tx, command_rx)?;
+        manager.run().await
+    })
+}
+
+impl InputManagerRuntime {
+    fn new(
+        shortcuts: ShortcutsConfig,
+        event_tx: mpsc::Sender<ShortcutEvent>,
+        command_rx: mpsc::UnboundedReceiver<InputManagerCommand>,
+    ) -> Result<Self> {
+        let registry = KeyboardRegistry::open_initial()?;
+        let shortcuts = ShortcutController::new(shortcuts)?;
+
+        Ok(Self {
+            command_rx,
+            event_tx,
+            registry,
+            shortcuts,
+            coalescer: UdevCoalescer::default(),
+            stats: InputStats::default(),
+            app_busy: false,
+            last_busy_log: Instant::now(),
+        })
+    }
+
+    async fn run(mut self) -> Result<()> {
+        let mut udev_stream = match create_udev_stream() {
+            Ok(stream) => Some(stream),
+            Err(err) => {
+                warn!(
+                    "Input device monitor unavailable ({}); falling back to periodic rescan",
+                    err
+                );
+                self.coalescer.fallback_rescan = true;
+                None
+            }
+        };
+        let mut evdev_tick = time::interval(EVDEV_TICK);
+        evdev_tick.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+        let mut refresh_tick = time::interval(Duration::from_millis(50));
+        refresh_tick.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+
+        info!("Input manager started");
+
+        loop {
+            let mut busy = false;
+
+            tokio::select! {
+                command = self.command_rx.recv() => {
+                    match command {
+                        Some(InputManagerCommand::UpdateShortcuts(shortcuts)) => {
+                            let releases = self.shortcuts.replace_shortcuts(shortcuts, self.registry.pressed_keys())?;
+                            for event in releases {
+                                self.emit_shortcut(event);
+                            }
+                            busy = true;
+                        }
+                        Some(InputManagerCommand::SetAppBusy(app_busy)) => {
+                            self.app_busy = app_busy;
+                        }
+                        Some(InputManagerCommand::Snapshot(reply_tx)) => {
+                            let _ = reply_tx.send(self.snapshot());
+                        }
+                        Some(InputManagerCommand::Shutdown) | None => {
+                            info!("Input manager shutting down");
+                            break;
+                        }
+                    }
+                }
+                event = next_udev_event(&mut udev_stream), if udev_stream.is_some() && !self.coalescer.has_pending_refresh() => {
+                    match event {
+                        Some(Ok(event)) => {
+                            if self.coalescer.mark_dirty_event(&event, &mut self.stats) {
+                                busy = true;
+                            }
+                        }
+                        Some(Err(err)) => {
+                            warn!("Input device monitor unavailable ({}); falling back to periodic rescan", err);
+                            self.coalescer.fallback_rescan = true;
+                            udev_stream = None;
+                        }
+                        None => {
+                            warn!("Input device monitor closed; falling back to periodic rescan");
+                            self.coalescer.fallback_rescan = true;
+                            udev_stream = None;
+                        }
+                    }
+                }
+                _ = refresh_tick.tick() => {
+                    if self.coalescer.refresh_due() {
+                        self.refresh_devices()?;
+                        busy = true;
+                    }
+                }
+                _ = evdev_tick.tick() => {
+                    let key_events = self.registry.poll_key_events(MAX_KEY_EVENTS_PER_TICK)?;
+                    if key_events > 0 {
+                        self.stats.key_events_seen += key_events as u64;
+                        let now = Instant::now();
+                        for event in self.shortcuts.apply_key_state(self.registry.pressed_keys(), now) {
+                            self.emit_shortcut(event);
+                        }
+                        busy = true;
+                    }
+                }
+            }
+
+            if busy {
+                self.stats.loop_busy_ticks += 1;
+                self.log_if_busy();
+            }
+        }
+
+        Ok(())
+    }
+
+    fn refresh_devices(&mut self) -> Result<()> {
+        let changed = self.registry.refresh()?;
+        self.stats.device_refreshes += 1;
+        self.coalescer.clear_dirty();
+
+        if changed {
+            if let Some(event) = self.shortcuts.on_device_set_changed() {
+                self.emit_shortcut(event);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn emit_shortcut(&mut self, event: ShortcutEvent) {
+        let phase = event.phase;
+        if let Err(err) = self.event_tx.try_send(event) {
+            match phase {
+                ShortcutPhase::Start => warn!("Failed to send shortcut start event: {}", err),
+                ShortcutPhase::End => {
+                    debug!("Dropped shortcut end event under backpressure: {}", err)
+                }
+            }
+            return;
+        }
+        self.stats.shortcut_events_emitted += 1;
+    }
+
+    fn snapshot(&self) -> InputSnapshot {
+        InputSnapshot {
+            device_count: self.registry.device_count(),
+            devices: self.registry.device_paths(),
+            shortcuts: self.shortcuts.summaries(),
+            app_busy: self.app_busy,
+            stats: self.stats.clone(),
+        }
+    }
+
+    fn log_if_busy(&mut self) {
+        if self.last_busy_log.elapsed() < Duration::from_secs(60) {
+            return;
+        }
+
+        if !self.app_busy && self.stats.loop_busy_ticks > 1_000 {
+            warn!(
+                udev_events_seen = self.stats.udev_events_seen,
+                udev_events_coalesced = self.stats.udev_events_coalesced,
+                device_refreshes = self.stats.device_refreshes,
+                key_events_seen = self.stats.key_events_seen,
+                shortcut_events_emitted = self.stats.shortcut_events_emitted,
+                loop_busy_ticks = self.stats.loop_busy_ticks,
+                "Input manager busy while idle"
+            );
+        }
+
+        self.stats.loop_busy_ticks = 0;
+        self.last_busy_log = Instant::now();
+    }
+}
+
+impl UdevCoalescer {
+    fn mark_dirty_event(&mut self, event: &tokio_udev::Event, stats: &mut InputStats) -> bool {
+        let Some(path) = event.device().devnode().map(Path::to_path_buf) else {
+            return false;
+        };
+        if !is_input_event_node(&path) {
+            return false;
+        }
+        if !matches!(
+            event.event_type(),
+            EventType::Add | EventType::Remove | EventType::Change
+        ) {
+            return false;
+        }
+
+        stats.udev_events_seen += 1;
+        let now = Instant::now();
+        if self.dirty_since.is_some() {
+            stats.udev_events_coalesced += 1;
+        } else {
+            self.dirty_since = Some(now);
+        }
+        self.last_event_at = Some(now);
+        true
+    }
+
+    fn refresh_due(&mut self) -> bool {
+        if self.fallback_rescan {
+            let now = Instant::now();
+            let due = self
+                .last_fallback_rescan
+                .is_none_or(|last| now.duration_since(last) >= Duration::from_secs(1));
+            if due {
+                self.last_fallback_rescan = Some(now);
+                return true;
+            }
+        }
+
+        let Some(dirty_since) = self.dirty_since else {
+            return false;
+        };
+        let now = Instant::now();
+        let quiet_for = self.last_event_at.map(|at| now.duration_since(at));
+        now.duration_since(dirty_since) >= UDEV_MAX_WAIT
+            || quiet_for.is_some_and(|elapsed| elapsed >= UDEV_DEBOUNCE)
+    }
+
+    fn clear_dirty(&mut self) {
+        self.dirty_since = None;
+        self.last_event_at = None;
+    }
+
+    fn has_pending_refresh(&self) -> bool {
+        self.dirty_since.is_some()
+    }
+}
+
+fn create_udev_stream() -> Result<AsyncMonitorSocket> {
+    let monitor = MonitorBuilder::new()?
+        // Keep the kernel filter at subsystem=input. Some keyboards do not
+        // consistently expose a devtype/tag that is safe to require here.
+        .match_subsystem("input")?
+        .listen()
+        .context("failed to listen for input udev events")?;
+    AsyncMonitorSocket::new(monitor).context("failed to create async udev monitor socket")
+}
+
+async fn next_udev_event(
+    stream: &mut Option<AsyncMonitorSocket>,
+) -> Option<Result<tokio_udev::Event, io::Error>> {
+    match stream {
+        Some(stream) => stream.next().await,
+        None => future::pending().await,
+    }
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,5 +1,9 @@
 pub mod injector;
+pub mod manager;
+mod registry;
 pub mod shortcuts;
 
 pub use injector::TextInjector;
-pub use shortcuts::{GlobalShortcuts, ShortcutEvent, ShortcutKind, ShortcutPhase};
+pub use manager::{InputManagerHandle, InputSnapshot, InputStats};
+pub use registry::list_available_keyboards;
+pub use shortcuts::{ShortcutEvent, ShortcutKind, ShortcutPhase};

--- a/src/input/registry.rs
+++ b/src/input/registry.rs
@@ -11,6 +11,12 @@ pub(super) struct KeyboardRegistry {
     pressed_keys: HashSet<Key>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct PollOutcome {
+    pub key_events: usize,
+    pub devices_changed: bool,
+}
+
 struct KeyboardDevice {
     path: PathBuf,
     name: String,
@@ -47,8 +53,8 @@ impl KeyboardRegistry {
             .collect()
     }
 
-    pub(super) fn poll_key_events(&mut self, max_events: usize) -> Result<usize> {
-        let mut count = 0;
+    pub(super) fn poll_key_events(&mut self, max_events: usize) -> Result<PollOutcome> {
+        let mut outcome = PollOutcome::default();
         let mut removed_devices = HashSet::new();
 
         for entry in &mut self.devices {
@@ -59,18 +65,18 @@ impl KeyboardRegistry {
                             match event.value() {
                                 1 => {
                                     self.pressed_keys.insert(key);
-                                    count += 1;
+                                    outcome.key_events += 1;
                                 }
                                 0 => {
                                     self.pressed_keys.remove(&key);
-                                    count += 1;
+                                    outcome.key_events += 1;
                                 }
                                 _ => {}
                             }
                         }
 
-                        if count >= max_events {
-                            return Ok(count);
+                        if outcome.key_events >= max_events {
+                            return Ok(outcome);
                         }
                     }
                 }
@@ -89,9 +95,10 @@ impl KeyboardRegistry {
             self.devices
                 .retain(|device| !removed_devices.contains(&device.path));
             self.pressed_keys.clear();
+            outcome.devices_changed = true;
         }
 
-        Ok(count)
+        Ok(outcome)
     }
 
     pub(super) fn refresh(&mut self) -> Result<bool> {

--- a/src/input/registry.rs
+++ b/src/input/registry.rs
@@ -1,0 +1,207 @@
+use anyhow::Result;
+use evdev::{Device, InputEventKind, Key};
+use std::collections::HashSet;
+use std::io;
+use std::os::fd::AsRawFd;
+use std::path::{Path, PathBuf};
+use tracing::{debug, error, info, warn};
+
+pub(super) struct KeyboardRegistry {
+    devices: Vec<KeyboardDevice>,
+    pressed_keys: HashSet<Key>,
+}
+
+struct KeyboardDevice {
+    path: PathBuf,
+    name: String,
+    device: Device,
+}
+
+impl KeyboardRegistry {
+    pub(super) fn open_initial() -> Result<Self> {
+        let devices = Self::find_keyboard_devices(true)?;
+        if devices.is_empty() {
+            warn!("No keyboard devices found!");
+            warn!("Make sure you have read permissions for /dev/input/event*");
+            warn!("You may need to add your user to the 'input' group");
+        }
+
+        Ok(Self {
+            devices,
+            pressed_keys: HashSet::new(),
+        })
+    }
+
+    pub(super) fn pressed_keys(&self) -> &HashSet<Key> {
+        &self.pressed_keys
+    }
+
+    pub(super) fn device_count(&self) -> usize {
+        self.devices.len()
+    }
+
+    pub(super) fn device_paths(&self) -> Vec<PathBuf> {
+        self.devices
+            .iter()
+            .map(|device| device.path.clone())
+            .collect()
+    }
+
+    pub(super) fn poll_key_events(&mut self, max_events: usize) -> Result<usize> {
+        let mut count = 0;
+        let mut removed_devices = HashSet::new();
+
+        for entry in &mut self.devices {
+            match entry.device.fetch_events() {
+                Ok(events) => {
+                    for event in events {
+                        if let InputEventKind::Key(key) = event.kind() {
+                            match event.value() {
+                                1 => {
+                                    self.pressed_keys.insert(key);
+                                    count += 1;
+                                }
+                                0 => {
+                                    self.pressed_keys.remove(&key);
+                                    count += 1;
+                                }
+                                _ => {}
+                            }
+                        }
+
+                        if count >= max_events {
+                            return Ok(count);
+                        }
+                    }
+                }
+                Err(err) => {
+                    if err.kind() != io::ErrorKind::WouldBlock {
+                        error!("Error fetching input events from {:?}: {}", entry.path, err);
+                        if is_device_disconnect_error(&err) {
+                            removed_devices.insert(entry.path.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        if !removed_devices.is_empty() {
+            self.devices
+                .retain(|device| !removed_devices.contains(&device.path));
+            self.pressed_keys.clear();
+        }
+
+        Ok(count)
+    }
+
+    pub(super) fn refresh(&mut self) -> Result<bool> {
+        let previous_paths: HashSet<PathBuf> = self
+            .devices
+            .iter()
+            .map(|device| device.path.clone())
+            .collect();
+        let devices = Self::find_keyboard_devices(false)?;
+        let updated_paths: HashSet<PathBuf> =
+            devices.iter().map(|device| device.path.clone()).collect();
+        let changed = previous_paths != updated_paths;
+
+        if changed {
+            info!(
+                "Keyboard devices refreshed - monitoring {} device(s)",
+                devices.len()
+            );
+            debug!(
+                devices = ?devices
+                    .iter()
+                    .map(|device| (&device.path, &device.name))
+                    .collect::<Vec<_>>(),
+                "Keyboard device set changed"
+            );
+            self.pressed_keys.clear();
+        } else {
+            debug!(
+                "Keyboard devices refreshed - monitoring {} device(s)",
+                devices.len()
+            );
+        }
+
+        self.devices = devices;
+        Ok(changed)
+    }
+
+    fn find_keyboard_devices(log_devices: bool) -> Result<Vec<KeyboardDevice>> {
+        let mut keyboards = Vec::new();
+
+        for (path, device) in evdev::enumerate() {
+            if is_keyboard_device(&device) {
+                if let Err(err) = set_device_nonblocking(&device) {
+                    warn!("Failed to set non-blocking mode for {:?}: {}", path, err);
+                }
+                let name = device.name().unwrap_or("Unknown").to_string();
+                if log_devices {
+                    info!("Found keyboard device: {} at {:?}", name, path);
+                }
+                keyboards.push(KeyboardDevice { path, name, device });
+            }
+        }
+
+        Ok(keyboards)
+    }
+}
+
+pub fn list_available_keyboards() -> Result<Vec<(PathBuf, String)>> {
+    let mut keyboards = Vec::new();
+
+    for (path, device) in evdev::enumerate() {
+        if is_keyboard_device(&device) {
+            let name = device.name().unwrap_or("Unknown").to_string();
+            keyboards.push((path, name));
+        }
+    }
+
+    Ok(keyboards)
+}
+
+fn is_keyboard_device(device: &Device) -> bool {
+    device.supported_keys().is_some_and(|keys| {
+        keys.contains(Key::KEY_A) && keys.contains(Key::KEY_S) && keys.contains(Key::KEY_D)
+    })
+}
+
+fn is_device_disconnect_error(err: &io::Error) -> bool {
+    matches!(
+        err.raw_os_error(),
+        Some(code) if code == libc::ENODEV || code == libc::EBADF || code == libc::ENXIO
+    )
+}
+
+fn set_device_nonblocking(device: &Device) -> Result<()> {
+    let fd = device.as_raw_fd();
+
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(anyhow::anyhow!(
+            "fcntl(F_GETFL) failed: {}",
+            io::Error::last_os_error()
+        ));
+    }
+
+    if (flags & libc::O_NONBLOCK) != 0 {
+        return Ok(());
+    }
+
+    let result = unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+    if result < 0 {
+        return Err(anyhow::anyhow!(
+            "fcntl(F_SETFL) failed: {}",
+            io::Error::last_os_error()
+        ));
+    }
+
+    Ok(())
+}
+
+pub(super) fn is_input_event_node(path: &Path) -> bool {
+    path.to_str()
+        .is_some_and(|node| node.starts_with("/dev/input/event"))
+}

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -1,17 +1,9 @@
 use anyhow::{Context, Result};
-use evdev::{Device, InputEventKind, Key};
+use evdev::Key;
 use std::collections::HashSet;
-use std::io;
-use std::os::fd::AsRawFd;
-use std::path::{Path, PathBuf};
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    mpsc as std_mpsc, Arc,
-};
 use std::time::{Duration, Instant};
-use tokio::sync::mpsc;
-use tracing::{debug, error, info, warn};
-use udev::{EventType, MonitorBuilder};
+
+use crate::config::ShortcutsConfig;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShortcutKind {
@@ -32,677 +24,322 @@ pub struct ShortcutEvent {
     pub phase: ShortcutPhase,
 }
 
-pub struct GlobalShortcuts {
-    devices: Vec<KeyboardDevice>,
-    target_keys: HashSet<Key>,
-    shortcut_name: String,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShortcutSummary {
+    pub kind: ShortcutKind,
+    pub name: String,
+    pub active: bool,
+}
+
+#[derive(Debug)]
+pub(super) struct ShortcutController {
+    bindings: Vec<ShortcutBinding>,
+}
+
+#[derive(Debug)]
+struct ShortcutBinding {
     kind: ShortcutKind,
+    name: String,
+    keys: HashSet<Key>,
+    active: bool,
+    last_trigger: Instant,
 }
 
-struct KeyboardDevice {
-    path: PathBuf,
-    device: Device,
-}
-
-#[derive(Debug, Clone)]
-enum InputDeviceEvent {
-    Added(PathBuf),
-    Removed(PathBuf),
-    Changed(PathBuf),
-    MonitorUnavailable(String),
-}
-
-impl GlobalShortcuts {
-    pub fn new(shortcut: &str, kind: ShortcutKind) -> Result<Self> {
-        let target_keys = Self::parse_shortcut(shortcut)?;
-        let devices = Self::find_keyboard_devices(true)?;
-
-        if devices.is_empty() {
-            return Err(anyhow::anyhow!("No keyboard devices found"));
-        }
-
-        let mode_label = match kind {
-            ShortcutKind::Hold => "hold",
-            ShortcutKind::Press => "press",
+impl ShortcutController {
+    pub(super) fn new(shortcuts: ShortcutsConfig) -> Result<Self> {
+        let mut controller = Self {
+            bindings: Vec::new(),
         };
-
-        info!(
-            "Global shortcuts initialized - monitoring {} device(s) for {} shortcut: {}",
-            devices.len(),
-            mode_label,
-            shortcut
-        );
-        debug!("Target keys: {:?}", target_keys);
-
-        Ok(Self {
-            devices,
-            target_keys,
-            shortcut_name: shortcut.to_string(),
-            kind,
-        })
+        controller.replace_shortcuts(shortcuts, &HashSet::new())?;
+        Ok(controller)
     }
 
-    pub fn run(mut self, tx: mpsc::Sender<ShortcutEvent>, stop: Arc<AtomicBool>) -> Result<()> {
-        let mut pressed_keys: HashSet<Key> = HashSet::new();
-        let mut last_trigger = Instant::now() - Duration::from_secs(10);
-        let debounce_duration = Duration::from_millis(500);
-        let mut combination_active = false;
-        let fallback_rescan_interval = Duration::from_secs(1);
-        let mut fallback_rescan_enabled = false;
-        let mut last_fallback_rescan = Instant::now();
-        let (rescan_tx, rescan_rx) = std_mpsc::channel();
-        let monitor_stop = stop.clone();
-        std::thread::spawn(move || {
-            let monitor_tx = rescan_tx.clone();
-            if let Err(err) = Self::watch_input_devices(monitor_tx, monitor_stop) {
-                let _ = rescan_tx.send(InputDeviceEvent::MonitorUnavailable(err.to_string()));
-            }
-        });
+    pub(super) fn replace_shortcuts(
+        &mut self,
+        shortcuts: ShortcutsConfig,
+        pressed_keys: &HashSet<Key>,
+    ) -> Result<Vec<ShortcutEvent>> {
+        let mut releases = Vec::new();
+        let mut next = Vec::new();
 
-        let listen_label = match self.kind {
-            ShortcutKind::Hold => "hold",
-            ShortcutKind::Press => "press",
-        };
-        info!(
-            "🎯 Listening for {} shortcut: {}",
-            listen_label, self.shortcut_name
-        );
+        if let Some(shortcut) = shortcuts.press {
+            next.push(ShortcutBinding::new(ShortcutKind::Press, shortcut)?);
+        }
+        if let Some(shortcut) = shortcuts.hold {
+            next.push(ShortcutBinding::new(ShortcutKind::Hold, shortcut)?);
+        }
 
-        'outer: loop {
-            if stop.load(Ordering::Relaxed) {
-                info!("Stopping shortcut listener: {}", self.shortcut_name);
-                break 'outer;
-            }
-
-            while let Ok(event) = rescan_rx.try_recv() {
-                match event {
-                    InputDeviceEvent::MonitorUnavailable(reason) => {
-                        if !fallback_rescan_enabled {
-                            warn!(
-                                "Input device monitor unavailable ({}); falling back to periodic rescan",
-                                reason
-                            );
-                        }
-                        fallback_rescan_enabled = true;
-                        last_fallback_rescan = Instant::now() - fallback_rescan_interval;
-                    }
-                    _ => {
-                        self.handle_input_device_event(event);
-                        pressed_keys.clear();
-                        release_hold_shortcut_on_input_change(
-                            &tx,
-                            self.kind,
-                            &mut combination_active,
-                        );
-                    }
-                }
-            }
-
-            let mut removed_devices = HashSet::new();
-
-            let target_keys = &self.target_keys;
-            let shortcut_name = &self.shortcut_name;
-
-            for entry in &mut self.devices {
-                if stop.load(Ordering::Relaxed) {
-                    break 'outer;
-                }
-                // Fetch events from this device
-                match entry.device.fetch_events() {
-                    Ok(events) => {
-                        for event in events {
-                            if stop.load(Ordering::Relaxed) {
-                                break 'outer;
-                            }
-                            match event.kind() {
-                                InputEventKind::Key(key) => {
-                                    let value = event.value();
-
-                                    match value {
-                                        // Key pressed
-                                        1 => {
-                                            pressed_keys.insert(key);
-
-                                            // Check if target combination is pressed
-                                            if target_keys.is_subset(&pressed_keys)
-                                                && !combination_active
-                                            {
-                                                let now = Instant::now();
-
-                                                // Debounce: only trigger if enough time has passed
-                                                let should_trigger = match self.kind {
-                                                    ShortcutKind::Hold => true,
-                                                    ShortcutKind::Press => {
-                                                        now.duration_since(last_trigger)
-                                                            > debounce_duration
-                                                    }
-                                                };
-
-                                                if should_trigger {
-                                                    debug!(
-                                                        "✓ Combination active: {:?}",
-                                                        target_keys
-                                                    );
-                                                    info!(
-                                                        "✨ Shortcut triggered: {}",
-                                                        shortcut_name
-                                                    );
-                                                    last_trigger = now;
-                                                    combination_active = true;
-
-                                                    if let Err(e) = tx.try_send(ShortcutEvent {
-                                                        triggered_at: now,
-                                                        kind: self.kind,
-                                                        phase: ShortcutPhase::Start,
-                                                    }) {
-                                                        warn!(
-                                                            "Failed to send shortcut event: {}",
-                                                            e
-                                                        );
-                                                    }
-                                                } else {
-                                                    debug!("Shortcut debounced (too soon)");
-                                                }
-                                            }
-                                        }
-                                        // Key released
-                                        0 => {
-                                            pressed_keys.remove(&key);
-
-                                            if combination_active
-                                                && !target_keys.is_subset(&pressed_keys)
-                                            {
-                                                debug!(
-                                                    "✗ Combination broken by releasing: {:?}",
-                                                    key
-                                                );
-                                                combination_active = false;
-
-                                                if matches!(self.kind, ShortcutKind::Hold) {
-                                                    if let Err(e) = tx.try_send(ShortcutEvent {
-                                                        triggered_at: Instant::now(),
-                                                        kind: self.kind,
-                                                        phase: ShortcutPhase::End,
-                                                    }) {
-                                                        warn!(
-                                                            "Failed to send shortcut release event: {}",
-                                                            e
-                                                        );
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        _ => {}
-                                    }
-                                }
-                                _ => {}
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        if e.kind() != std::io::ErrorKind::WouldBlock {
-                            error!("Error fetching events: {}", e);
-
-                            if is_device_disconnect_error(&e) {
-                                warn!("Input device went away; removing device");
-                                removed_devices.insert(entry.path.clone());
-                            }
-                        }
-                        if stop.load(Ordering::Relaxed) {
-                            break 'outer;
-                        }
-                    }
-                }
-            }
-
-            if !removed_devices.is_empty() {
-                let before = self.devices.len();
-                self.devices
-                    .retain(|device| !removed_devices.contains(&device.path));
-                let removed = before.saturating_sub(self.devices.len());
-                if removed > 0 {
-                    info!("Removed {} keyboard device(s)", removed);
-                }
-                pressed_keys.clear();
-                release_hold_shortcut_on_input_change(&tx, self.kind, &mut combination_active);
-            }
-
-            if fallback_rescan_enabled && last_fallback_rescan.elapsed() >= fallback_rescan_interval
+        for old in &self.bindings {
+            if old.kind == ShortcutKind::Hold
+                && old.active
+                && !next
+                    .iter()
+                    .any(|new| new.kind == old.kind && new.name == old.name)
             {
-                last_fallback_rescan = Instant::now();
-                match self.refresh_devices() {
-                    Ok(true) => {
-                        pressed_keys.clear();
-                        release_hold_shortcut_on_input_change(
-                            &tx,
-                            self.kind,
-                            &mut combination_active,
-                        );
+                releases.push(ShortcutEvent {
+                    triggered_at: Instant::now(),
+                    kind: ShortcutKind::Hold,
+                    phase: ShortcutPhase::End,
+                });
+            }
+        }
+
+        for binding in &mut next {
+            if let Some(old) = self
+                .bindings
+                .iter()
+                .find(|old| old.kind == binding.kind && old.name == binding.name)
+            {
+                binding.active = old.active && binding.keys.is_subset(pressed_keys);
+                binding.last_trigger = old.last_trigger;
+            }
+        }
+
+        self.bindings = next;
+        Ok(releases)
+    }
+
+    pub(super) fn apply_key_state(
+        &mut self,
+        pressed_keys: &HashSet<Key>,
+        now: Instant,
+    ) -> Vec<ShortcutEvent> {
+        let mut events = Vec::new();
+
+        for binding in &mut self.bindings {
+            let combination_pressed = binding.keys.is_subset(pressed_keys);
+
+            if combination_pressed && !binding.active {
+                let should_trigger = match binding.kind {
+                    ShortcutKind::Hold => true,
+                    ShortcutKind::Press => {
+                        now.duration_since(binding.last_trigger) > Duration::from_millis(500)
                     }
-                    Ok(false) => {}
-                    Err(err) => {
-                        error!("Failed to refresh keyboard devices: {}", err);
-                    }
+                };
+
+                if should_trigger {
+                    binding.active = true;
+                    binding.last_trigger = now;
+                    events.push(ShortcutEvent {
+                        triggered_at: now,
+                        kind: binding.kind,
+                        phase: ShortcutPhase::Start,
+                    });
+                }
+            } else if !combination_pressed && binding.active {
+                binding.active = false;
+                if binding.kind == ShortcutKind::Hold {
+                    events.push(ShortcutEvent {
+                        triggered_at: now,
+                        kind: ShortcutKind::Hold,
+                        phase: ShortcutPhase::End,
+                    });
                 }
             }
-
-            // Small sleep to prevent busy-waiting
-            std::thread::sleep(Duration::from_millis(10));
         }
 
-        Ok(())
+        events
     }
 
-    fn parse_shortcut(shortcut: &str) -> Result<HashSet<Key>> {
-        let mut keys = HashSet::new();
+    pub(super) fn on_device_set_changed(&mut self) -> Option<ShortcutEvent> {
+        let mut released = false;
 
-        for part in shortcut.split('+') {
-            let part = part.trim().to_uppercase();
-            let key =
-                Self::parse_key(&part).with_context(|| format!("Failed to parse key: {}", part))?;
-            keys.insert(key);
-        }
-
-        if keys.is_empty() {
-            return Err(anyhow::anyhow!("Empty shortcut"));
-        }
-
-        Ok(keys)
-    }
-
-    fn parse_key(key_str: &str) -> Result<Key> {
-        match key_str {
-            // Modifiers
-            "SUPER" | "META" | "WIN" | "WINDOWS" => Ok(Key::KEY_LEFTMETA),
-            "ALT" => Ok(Key::KEY_LEFTALT),
-            "CTRL" | "CONTROL" => Ok(Key::KEY_LEFTCTRL),
-            "SHIFT" => Ok(Key::KEY_LEFTSHIFT),
-
-            // Function keys
-            "F1" => Ok(Key::KEY_F1),
-            "F2" => Ok(Key::KEY_F2),
-            "F3" => Ok(Key::KEY_F3),
-            "F4" => Ok(Key::KEY_F4),
-            "F5" => Ok(Key::KEY_F5),
-            "F6" => Ok(Key::KEY_F6),
-            "F7" => Ok(Key::KEY_F7),
-            "F8" => Ok(Key::KEY_F8),
-            "F9" => Ok(Key::KEY_F9),
-            "F10" => Ok(Key::KEY_F10),
-            "F11" => Ok(Key::KEY_F11),
-            "F12" => Ok(Key::KEY_F12),
-
-            // Letter keys
-            "A" => Ok(Key::KEY_A),
-            "B" => Ok(Key::KEY_B),
-            "C" => Ok(Key::KEY_C),
-            "D" => Ok(Key::KEY_D),
-            "E" => Ok(Key::KEY_E),
-            "F" => Ok(Key::KEY_F),
-            "G" => Ok(Key::KEY_G),
-            "H" => Ok(Key::KEY_H),
-            "I" => Ok(Key::KEY_I),
-            "J" => Ok(Key::KEY_J),
-            "K" => Ok(Key::KEY_K),
-            "L" => Ok(Key::KEY_L),
-            "M" => Ok(Key::KEY_M),
-            "N" => Ok(Key::KEY_N),
-            "O" => Ok(Key::KEY_O),
-            "P" => Ok(Key::KEY_P),
-            "Q" => Ok(Key::KEY_Q),
-            "R" => Ok(Key::KEY_R),
-            "S" => Ok(Key::KEY_S),
-            "T" => Ok(Key::KEY_T),
-            "U" => Ok(Key::KEY_U),
-            "V" => Ok(Key::KEY_V),
-            "W" => Ok(Key::KEY_W),
-            "X" => Ok(Key::KEY_X),
-            "Y" => Ok(Key::KEY_Y),
-            "Z" => Ok(Key::KEY_Z),
-
-            // Number keys
-            "0" => Ok(Key::KEY_0),
-            "1" => Ok(Key::KEY_1),
-            "2" => Ok(Key::KEY_2),
-            "3" => Ok(Key::KEY_3),
-            "4" => Ok(Key::KEY_4),
-            "5" => Ok(Key::KEY_5),
-            "6" => Ok(Key::KEY_6),
-            "7" => Ok(Key::KEY_7),
-            "8" => Ok(Key::KEY_8),
-            "9" => Ok(Key::KEY_9),
-
-            // Special keys
-            "SPACE" => Ok(Key::KEY_SPACE),
-            "ENTER" | "RETURN" => Ok(Key::KEY_ENTER),
-            "ESC" | "ESCAPE" => Ok(Key::KEY_ESC),
-            "TAB" => Ok(Key::KEY_TAB),
-            "BACKSPACE" => Ok(Key::KEY_BACKSPACE),
-            "DELETE" | "DEL" => Ok(Key::KEY_DELETE),
-            "INSERT" | "INS" => Ok(Key::KEY_INSERT),
-            "HOME" => Ok(Key::KEY_HOME),
-            "END" => Ok(Key::KEY_END),
-            "PAGEUP" | "PGUP" => Ok(Key::KEY_PAGEUP),
-            "PAGEDOWN" | "PGDOWN" => Ok(Key::KEY_PAGEDOWN),
-
-            // Arrow keys
-            "UP" => Ok(Key::KEY_UP),
-            "DOWN" => Ok(Key::KEY_DOWN),
-            "LEFT" => Ok(Key::KEY_LEFT),
-            "RIGHT" => Ok(Key::KEY_RIGHT),
-
-            _ => Err(anyhow::anyhow!("Unknown key: {}", key_str)),
-        }
-    }
-
-    fn find_keyboard_devices(log_devices: bool) -> Result<Vec<KeyboardDevice>> {
-        let mut keyboards = Vec::new();
-
-        for (path, device) in evdev::enumerate() {
-            if Self::is_keyboard_device(&device) {
-                if let Err(err) = set_device_nonblocking(&device) {
-                    warn!("Failed to set non-blocking mode for {:?}: {}", path, err);
-                }
-                let name = device.name().unwrap_or("Unknown");
-                if log_devices {
-                    info!("Found keyboard device: {} at {:?}", name, path);
-                }
-                keyboards.push(KeyboardDevice { path, device });
+        for binding in &mut self.bindings {
+            if binding.kind == ShortcutKind::Hold && binding.active {
+                binding.active = false;
+                released = true;
             }
         }
 
-        if keyboards.is_empty() {
-            warn!("No keyboard devices found!");
-            warn!("Make sure you have read permissions for /dev/input/event*");
-            warn!("You may need to add your user to the 'input' group");
-        }
-
-        Ok(keyboards)
-    }
-
-    pub fn list_available_keyboards() -> Result<Vec<(PathBuf, String)>> {
-        let mut keyboards = Vec::new();
-
-        for (path, device) in evdev::enumerate() {
-            if Self::is_keyboard_device(&device) {
-                let name = device.name().unwrap_or("Unknown").to_string();
-                keyboards.push((path, name));
-            }
-        }
-
-        Ok(keyboards)
-    }
-
-    fn refresh_devices(&mut self) -> Result<bool> {
-        let previous_paths: HashSet<PathBuf> = self
-            .devices
-            .iter()
-            .map(|device| device.path.clone())
-            .collect();
-        let devices = Self::find_keyboard_devices(false)?;
-        let previous = self.devices.len();
-        let updated = devices.len();
-        let updated_paths: HashSet<PathBuf> =
-            devices.iter().map(|device| device.path.clone()).collect();
-        let changed = previous_paths != updated_paths;
-
-        if updated == 0 && previous != 0 {
-            warn!("No keyboard devices found!");
-        } else if updated != previous {
-            info!(
-                "Keyboard devices refreshed - monitoring {} device(s)",
-                updated
-            );
-        } else {
-            debug!(
-                "Keyboard devices refreshed - monitoring {} device(s)",
-                updated
-            );
-        }
-
-        self.devices = devices;
-
-        Ok(changed)
-    }
-
-    fn is_keyboard_device(device: &Device) -> bool {
-        device.supported_keys().is_some_and(|keys| {
-            keys.contains(Key::KEY_A) && keys.contains(Key::KEY_S) && keys.contains(Key::KEY_D)
+        released.then(|| ShortcutEvent {
+            triggered_at: Instant::now(),
+            kind: ShortcutKind::Hold,
+            phase: ShortcutPhase::End,
         })
     }
 
-    fn open_keyboard_device(path: &Path) -> Result<Option<KeyboardDevice>> {
-        let device = Device::open(path)?;
-        if !Self::is_keyboard_device(&device) {
-            return Ok(None);
-        }
-        if let Err(err) = set_device_nonblocking(&device) {
-            warn!("Failed to set non-blocking mode for {:?}: {}", path, err);
-        }
-        let name = device.name().unwrap_or("Unknown");
-        info!("Found keyboard device: {} at {:?}", name, path);
-        Ok(Some(KeyboardDevice {
-            path: path.to_path_buf(),
-            device,
-        }))
-    }
-
-    fn handle_input_device_event(&mut self, event: InputDeviceEvent) {
-        match event {
-            InputDeviceEvent::Added(path) => self.add_keyboard_device(path),
-            InputDeviceEvent::Removed(path) => self.remove_keyboard_device(&path),
-            InputDeviceEvent::Changed(path) => {
-                self.remove_keyboard_device(&path);
-                self.add_keyboard_device(path);
-            }
-            InputDeviceEvent::MonitorUnavailable(_) => {}
-        }
-    }
-
-    fn add_keyboard_device(&mut self, path: PathBuf) {
-        if self.devices.iter().any(|device| device.path == path) {
-            return;
-        }
-        match Self::open_keyboard_device(&path) {
-            Ok(Some(device)) => {
-                self.devices.push(device);
-                info!(
-                    "Keyboard devices refreshed - monitoring {} device(s)",
-                    self.devices.len()
-                );
-            }
-            Ok(None) => {
-                debug!("Input device added but not a keyboard: {:?}", path);
-            }
-            Err(err) => {
-                warn!("Failed to open input device {:?}: {}", path, err);
-            }
-        }
-    }
-
-    fn remove_keyboard_device(&mut self, path: &Path) {
-        let before = self.devices.len();
-        self.devices.retain(|device| device.path != path);
-        if self.devices.len() != before {
-            info!(
-                "Keyboard devices refreshed - monitoring {} device(s)",
-                self.devices.len()
-            );
-        }
-        if self.devices.is_empty() {
-            warn!("No keyboard devices found!");
-        }
-    }
-
-    fn watch_input_devices(
-        tx: std_mpsc::Sender<InputDeviceEvent>,
-        stop: Arc<AtomicBool>,
-    ) -> Result<()> {
-        let monitor = MonitorBuilder::new()?.match_subsystem("input")?.listen()?;
-
-        loop {
-            if stop.load(Ordering::Relaxed) {
-                break;
-            }
-            let mut saw_event = false;
-            for event in monitor.iter() {
-                saw_event = true;
-                if stop.load(Ordering::Relaxed) {
-                    break;
-                }
-                let Some(path) = event.device().devnode().map(Path::to_path_buf) else {
-                    continue;
-                };
-                if !is_input_event_node(&path) {
-                    continue;
-                }
-                let event_type = match event.event_type() {
-                    EventType::Add => Some(InputDeviceEvent::Added(path)),
-                    EventType::Remove => Some(InputDeviceEvent::Removed(path)),
-                    EventType::Change => Some(InputDeviceEvent::Changed(path)),
-                    _ => None,
-                };
-                if let Some(event_type) = event_type {
-                    if tx.send(event_type).is_err() {
-                        return Ok(());
-                    }
-                }
-            }
-            if !saw_event {
-                std::thread::sleep(Duration::from_millis(100));
-            }
-        }
-
-        Ok(())
+    pub(super) fn summaries(&self) -> Vec<ShortcutSummary> {
+        self.bindings
+            .iter()
+            .map(|binding| ShortcutSummary {
+                kind: binding.kind,
+                name: binding.name.clone(),
+                active: binding.active,
+            })
+            .collect()
     }
 }
 
-fn release_hold_shortcut_on_input_change(
-    tx: &mpsc::Sender<ShortcutEvent>,
-    kind: ShortcutKind,
-    combination_active: &mut bool,
-) {
-    *combination_active = false;
-
-    if !matches!(kind, ShortcutKind::Hold) {
-        return;
-    }
-
-    if let Err(err) = tx.try_send(ShortcutEvent {
-        triggered_at: Instant::now(),
-        kind,
-        phase: ShortcutPhase::End,
-    }) {
-        warn!(
-            "Failed to send hold shortcut release event after input device change: {}",
-            err
-        );
+impl ShortcutBinding {
+    fn new(kind: ShortcutKind, name: String) -> Result<Self> {
+        Ok(Self {
+            kind,
+            keys: parse_shortcut(&name)?,
+            name,
+            active: false,
+            last_trigger: Instant::now() - Duration::from_secs(10),
+        })
     }
 }
 
-fn is_device_disconnect_error(err: &io::Error) -> bool {
-    match err.raw_os_error() {
-        Some(code) if code == libc::ENODEV || code == libc::EBADF || code == libc::ENXIO => true,
-        _ => false,
+pub(super) fn parse_shortcut(shortcut: &str) -> Result<HashSet<Key>> {
+    let mut keys = HashSet::new();
+
+    for part in shortcut.split('+') {
+        let part = part.trim().to_uppercase();
+        let key = parse_key(&part).with_context(|| format!("Failed to parse key: {}", part))?;
+        keys.insert(key);
     }
+
+    if keys.is_empty() {
+        return Err(anyhow::anyhow!("Empty shortcut"));
+    }
+
+    Ok(keys)
 }
 
-fn set_device_nonblocking(device: &Device) -> Result<()> {
-    let fd = device.as_raw_fd();
-
-    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
-    if flags < 0 {
-        return Err(anyhow::anyhow!(
-            "fcntl(F_GETFL) failed: {}",
-            std::io::Error::last_os_error()
-        ));
+fn parse_key(key_str: &str) -> Result<Key> {
+    match key_str {
+        "SUPER" | "META" | "WIN" | "WINDOWS" => Ok(Key::KEY_LEFTMETA),
+        "ALT" => Ok(Key::KEY_LEFTALT),
+        "CTRL" | "CONTROL" => Ok(Key::KEY_LEFTCTRL),
+        "SHIFT" => Ok(Key::KEY_LEFTSHIFT),
+        "F1" => Ok(Key::KEY_F1),
+        "F2" => Ok(Key::KEY_F2),
+        "F3" => Ok(Key::KEY_F3),
+        "F4" => Ok(Key::KEY_F4),
+        "F5" => Ok(Key::KEY_F5),
+        "F6" => Ok(Key::KEY_F6),
+        "F7" => Ok(Key::KEY_F7),
+        "F8" => Ok(Key::KEY_F8),
+        "F9" => Ok(Key::KEY_F9),
+        "F10" => Ok(Key::KEY_F10),
+        "F11" => Ok(Key::KEY_F11),
+        "F12" => Ok(Key::KEY_F12),
+        "A" => Ok(Key::KEY_A),
+        "B" => Ok(Key::KEY_B),
+        "C" => Ok(Key::KEY_C),
+        "D" => Ok(Key::KEY_D),
+        "E" => Ok(Key::KEY_E),
+        "F" => Ok(Key::KEY_F),
+        "G" => Ok(Key::KEY_G),
+        "H" => Ok(Key::KEY_H),
+        "I" => Ok(Key::KEY_I),
+        "J" => Ok(Key::KEY_J),
+        "K" => Ok(Key::KEY_K),
+        "L" => Ok(Key::KEY_L),
+        "M" => Ok(Key::KEY_M),
+        "N" => Ok(Key::KEY_N),
+        "O" => Ok(Key::KEY_O),
+        "P" => Ok(Key::KEY_P),
+        "Q" => Ok(Key::KEY_Q),
+        "R" => Ok(Key::KEY_R),
+        "S" => Ok(Key::KEY_S),
+        "T" => Ok(Key::KEY_T),
+        "U" => Ok(Key::KEY_U),
+        "V" => Ok(Key::KEY_V),
+        "W" => Ok(Key::KEY_W),
+        "X" => Ok(Key::KEY_X),
+        "Y" => Ok(Key::KEY_Y),
+        "Z" => Ok(Key::KEY_Z),
+        "0" => Ok(Key::KEY_0),
+        "1" => Ok(Key::KEY_1),
+        "2" => Ok(Key::KEY_2),
+        "3" => Ok(Key::KEY_3),
+        "4" => Ok(Key::KEY_4),
+        "5" => Ok(Key::KEY_5),
+        "6" => Ok(Key::KEY_6),
+        "7" => Ok(Key::KEY_7),
+        "8" => Ok(Key::KEY_8),
+        "9" => Ok(Key::KEY_9),
+        "SPACE" => Ok(Key::KEY_SPACE),
+        "ENTER" | "RETURN" => Ok(Key::KEY_ENTER),
+        "ESC" | "ESCAPE" => Ok(Key::KEY_ESC),
+        "TAB" => Ok(Key::KEY_TAB),
+        "BACKSPACE" => Ok(Key::KEY_BACKSPACE),
+        "DELETE" | "DEL" => Ok(Key::KEY_DELETE),
+        "INSERT" | "INS" => Ok(Key::KEY_INSERT),
+        "HOME" => Ok(Key::KEY_HOME),
+        "END" => Ok(Key::KEY_END),
+        "PAGEUP" | "PGUP" => Ok(Key::KEY_PAGEUP),
+        "PAGEDOWN" | "PGDOWN" => Ok(Key::KEY_PAGEDOWN),
+        "UP" => Ok(Key::KEY_UP),
+        "DOWN" => Ok(Key::KEY_DOWN),
+        "LEFT" => Ok(Key::KEY_LEFT),
+        "RIGHT" => Ok(Key::KEY_RIGHT),
+        _ => Err(anyhow::anyhow!("Unknown key: {}", key_str)),
     }
-
-    if (flags & libc::O_NONBLOCK) != 0 {
-        return Ok(());
-    }
-
-    let result = unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
-    if result < 0 {
-        return Err(anyhow::anyhow!(
-            "fcntl(F_SETFL) failed: {}",
-            std::io::Error::last_os_error()
-        ));
-    }
-
-    Ok(())
-}
-
-fn is_input_event_node(path: &Path) -> bool {
-    path.to_str()
-        .is_some_and(|node| node.starts_with("/dev/input/event"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io;
 
-    #[test]
-    fn detects_enodev_as_disconnect() {
-        let err = io::Error::from_raw_os_error(libc::ENODEV);
-        assert!(is_device_disconnect_error(&err));
+    fn config(press: Option<&str>, hold: Option<&str>) -> ShortcutsConfig {
+        ShortcutsConfig {
+            press: press.map(str::to_string),
+            hold: hold.map(str::to_string),
+        }
     }
 
     #[test]
-    fn does_not_treat_would_block_as_disconnect() {
-        let err = io::Error::from(io::ErrorKind::WouldBlock);
-        assert!(!is_device_disconnect_error(&err));
+    fn press_shortcut_debounces() {
+        let mut controller = ShortcutController::new(config(Some("SUPER+R"), None)).unwrap();
+        let keys = parse_shortcut("SUPER+R").unwrap();
+        let now = Instant::now();
+
+        let first = controller.apply_key_state(&keys, now);
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].kind, ShortcutKind::Press);
+        assert_eq!(first[0].phase, ShortcutPhase::Start);
+
+        let released = HashSet::new();
+        controller.apply_key_state(&released, now + Duration::from_millis(10));
+        let second = controller.apply_key_state(&keys, now + Duration::from_millis(100));
+        assert!(second.is_empty());
     }
 
     #[test]
-    fn does_not_treat_other_errors_as_disconnect() {
-        let err = io::Error::from(io::ErrorKind::BrokenPipe);
-        assert!(!is_device_disconnect_error(&err));
+    fn hold_shortcut_emits_start_and_end() {
+        let mut controller = ShortcutController::new(config(None, Some("SUPER+ALT"))).unwrap();
+        let keys = parse_shortcut("SUPER+ALT").unwrap();
+        let now = Instant::now();
+
+        let start = controller.apply_key_state(&keys, now);
+        assert_eq!(start.len(), 1);
+        assert_eq!(start[0].phase, ShortcutPhase::Start);
+
+        let released = HashSet::new();
+        let end = controller.apply_key_state(&released, now + Duration::from_millis(10));
+        assert_eq!(end.len(), 1);
+        assert_eq!(end[0].phase, ShortcutPhase::End);
     }
 
     #[test]
-    fn filters_input_event_nodes() {
-        assert!(is_input_event_node(Path::new("/dev/input/event0")));
-        assert!(is_input_event_node(Path::new("/dev/input/event10")));
-        assert!(!is_input_event_node(Path::new("/dev/input/mouse0")));
-        assert!(!is_input_event_node(Path::new("/tmp/event0")));
+    fn device_churn_emits_one_hold_end() {
+        let mut controller = ShortcutController::new(config(None, Some("SUPER+ALT"))).unwrap();
+        let keys = parse_shortcut("SUPER+ALT").unwrap();
+        controller.apply_key_state(&keys, Instant::now());
+
+        let first = controller.on_device_set_changed();
+        let second = controller.on_device_set_changed();
+
+        assert_eq!(first.unwrap().phase, ShortcutPhase::End);
+        assert!(second.is_none());
     }
 
     #[test]
-    fn active_hold_disconnect_emits_release() {
-        let (tx, mut rx) = mpsc::channel(1);
-        let mut combination_active = true;
+    fn config_update_removing_active_hold_emits_end() {
+        let mut controller = ShortcutController::new(config(None, Some("SUPER+ALT"))).unwrap();
+        let keys = parse_shortcut("SUPER+ALT").unwrap();
+        controller.apply_key_state(&keys, Instant::now());
 
-        release_hold_shortcut_on_input_change(&tx, ShortcutKind::Hold, &mut combination_active);
+        let releases = controller
+            .replace_shortcuts(config(Some("SUPER+R"), None), &keys)
+            .unwrap();
 
-        let event = rx.try_recv().expect("hold release event");
-        assert!(!combination_active);
-        assert_eq!(event.kind, ShortcutKind::Hold);
-        assert_eq!(event.phase, ShortcutPhase::End);
-    }
-
-    #[test]
-    fn inactive_hold_disconnect_still_emits_release() {
-        let (tx, mut rx) = mpsc::channel(1);
-        let mut combination_active = false;
-
-        release_hold_shortcut_on_input_change(&tx, ShortcutKind::Hold, &mut combination_active);
-
-        let event = rx.try_recv().expect("hold release event");
-        assert!(!combination_active);
-        assert_eq!(event.kind, ShortcutKind::Hold);
-        assert_eq!(event.phase, ShortcutPhase::End);
-    }
-
-    #[test]
-    fn active_press_disconnect_does_not_emit_release() {
-        let (tx, mut rx) = mpsc::channel(1);
-        let mut combination_active = true;
-
-        release_hold_shortcut_on_input_change(&tx, ShortcutKind::Press, &mut combination_active);
-
-        assert!(!combination_active);
-        assert!(rx.try_recv().is_err());
+        assert_eq!(releases.len(), 1);
+        assert_eq!(releases[0].kind, ShortcutKind::Hold);
+        assert_eq!(releases[0].phase, ShortcutPhase::End);
     }
 }

--- a/src/input/shortcuts.rs
+++ b/src/input/shortcuts.rs
@@ -342,4 +342,17 @@ mod tests {
         assert_eq!(releases[0].kind, ShortcutKind::Hold);
         assert_eq!(releases[0].phase, ShortcutPhase::End);
     }
+
+    #[test]
+    fn cleared_pressed_keys_releases_active_hold() {
+        let mut controller = ShortcutController::new(config(None, Some("SUPER+ALT"))).unwrap();
+        let keys = parse_shortcut("SUPER+ALT").unwrap();
+        controller.apply_key_state(&keys, Instant::now());
+
+        let end = controller.apply_key_state(&HashSet::new(), Instant::now());
+
+        assert_eq!(end.len(), 1);
+        assert_eq!(end[0].kind, ShortcutKind::Hold);
+        assert_eq!(end[0].phase, ShortcutPhase::End);
+    }
 }


### PR DESCRIPTION
#### What changed:
  - Replaced duplicate press/hold listener threads with one InputManagerHandle.
  - Added one input manager thread with current-thread Tokio runtime + tokio-udev.
  - Split input handling:
      - src/input/manager.rs
      - src/input/registry.rs
      - src/input/shortcuts.rs
  - Added coalesced udev refresh, bounded evdev polling, fallback periodic rescan, stats, snapshots, busy watchdog, app busy signal.
  - Added pure shortcut-controller regression tests: debounce, hold start/end, device churn release, config removal release.
  - Wired src/app.rs to one input manager.

impelements / fixes #141