### PR TITLE
chore: release v0.3.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.3.32] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.31...v0.3.32) - 2026-06-26
+
+### Fixes
+- refresh stale evdev devices ([#147](https://github.com/better-slop/hyprwhspr-rs/pull/147))
+
 ## [0.3.31] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.30...v0.3.31) - 2026-06-21
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "hyprwhspr-rs"
-version = "0.3.31"
+version = "0.3.32"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyprwhspr-rs"
-version = "0.3.31"
+version = "0.3.32"
 edition = "2021"
 authors = ["hyprwhspr-rs contributors"]
 description = "Native speech-to-text voice dictation for Hyprland (Rust implementation)"


### PR DESCRIPTION



## 🤖 New release

* `hyprwhspr-rs`: 0.3.31 -> 0.3.32 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.32] (https://github.com/better-slop/hyprwhspr-rs/compare/v0.3.31...v0.3.32) - 2026-06-26

### Fixes
- refresh stale evdev devices ([#147](https://github.com/better-slop/hyprwhspr-rs/pull/147))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).